### PR TITLE
fix(services): make request logger safe to capture in singleton services

### DIFF
--- a/.changeset/sweet-glasses-study.md
+++ b/.changeset/sweet-glasses-study.md
@@ -1,0 +1,7 @@
+---
+"@geekmidas/constructs": patch
+"@geekmidas/services": patch
+"@geekmidas/testkit": patch
+---
+
+Fix stale logger from service initialization

--- a/apps/docs/packages/services.md
+++ b/apps/docs/packages/services.md
@@ -144,6 +144,47 @@ await runWithRequestContext(
 );
 ```
 
+### Request-scoped logger in singleton services
+
+Services are **singletons** — `register()` runs once and the instance is cached and
+reused for every request. The per-request logger, however, changes on every request.
+
+To make this safe, `serviceContext.getLogger()` returns a **request-scoped proxy**:
+it re-resolves the current request's logger on every log call. This means a service
+can capture the logger **once** during `register()` and still log against the correct
+per-request logger:
+
+```typescript
+const databaseService = {
+  serviceName: 'database' as const,
+  register({ context }) {
+    // ✅ Safe: getLogger() returns a live proxy, not a frozen logger.
+    //    Each call routes to the CURRENT request's logger.
+    const logger = context.getLogger().child({ svc: 'db' });
+
+    return {
+      async query(sql: string) {
+        logger.debug({ sql }, 'Executing query');
+      },
+    };
+  },
+} satisfies Service<'database', Database>;
+```
+
+::: warning
+Before this proxy existed, capturing `context.getLogger()` in `register()` froze the
+**first** request's logger for the lifetime of the process, so later requests logged
+with the first request's `requestId` and user bindings. The proxy fixes this; just
+make sure you log **through** the value returned by `getLogger()` / `.child()` rather
+than snapshotting a concrete logger elsewhere.
+:::
+
+Calling a log method (or `getLogger()` itself) outside any request context throws.
+Guard detached/background work with `serviceContext.hasContext()`.
+
+See [Request-Scoped Logging in Singleton Services](https://github.com/geekmidas/toolbox/blob/main/packages/services/docs/request-scoped-logging.md)
+for the full problem description and implementation details.
+
 ## Service Interface
 
 ```typescript

--- a/packages/constructs/src/adaptors/__tests__/trpc.spec.ts
+++ b/packages/constructs/src/adaptors/__tests__/trpc.spec.ts
@@ -62,6 +62,7 @@ describe('createServicesMiddleware (with envParser)', () => {
 			register: () => ({
 				touch() {
 					observedLogger = serviceContext.getLogger();
+					observedLogger.info('touched');
 					return 'ok';
 				},
 			}),
@@ -83,7 +84,10 @@ describe('createServicesMiddleware (with envParser)', () => {
 
 		await caller.createCaller({ logger: requestLogger }).run();
 
-		expect(observedLogger).toBe(requestLogger);
+		// getLogger() returns a request-scoped proxy (not the raw logger), so we
+		// assert it delegates to the request logger rather than checking identity.
+		expect(observedLogger).not.toBeNull();
+		expect(requestLogger.info).toHaveBeenCalledWith('touched');
 	});
 
 	it('throws cleanly when service code runs outside the procedure', () => {
@@ -129,6 +133,7 @@ describe('createRequestContextMiddleware', () => {
 		const caller = t.router({
 			run: t.procedure.use(withRequestContext).query(() => {
 				observed = serviceContext.getLogger();
+				observed.info('handled');
 				return 'done';
 			}),
 		});
@@ -137,7 +142,9 @@ describe('createRequestContextMiddleware', () => {
 		const result = await caller.createCaller({ logger: requestLogger }).run();
 
 		expect(result).toBe('done');
-		expect(observed).toBe(requestLogger);
+		// The request-scoped proxy delegates to ctx.logger.
+		expect(observed).not.toBeNull();
+		expect(requestLogger.info).toHaveBeenCalledWith('handled');
 	});
 
 	it('auto-generates requestId and startTime when ctx does not provide them', async () => {

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -286,6 +286,30 @@ const db3 = await serviceDiscovery.discover(databaseService);
 console.log(db1 === db2 && db2 === db3); // true
 ```
 
+### Request-Scoped Logging
+
+Because services are singletons, `register()` runs **once** while the per-request
+logger changes on every request. `serviceContext.getLogger()` returns a
+**request-scoped proxy** that re-resolves the current request's logger on each call,
+so a service can safely capture the logger once during `register()` and still log
+against the correct request:
+
+```typescript
+register({ context }) {
+  const logger = context.getLogger().child({ svc: 'db' }); // ✅ safe to capture
+
+  return {
+    async query(sql: string) {
+      logger.debug({ sql }, 'Executing query'); // logs to the CURRENT request
+    },
+  };
+}
+```
+
+See [docs/request-scoped-logging.md](./docs/request-scoped-logging.md) for the full
+problem description (and the bug it prevents: a captured logger freezing the first
+request's `requestId` for every later request).
+
 ## Error Handling
 
 Handle service initialization errors gracefully:

--- a/packages/services/docs/request-scoped-logging.md
+++ b/packages/services/docs/request-scoped-logging.md
@@ -1,0 +1,153 @@
+# Request-Scoped Logging in Singleton Services
+
+## Problem
+
+Services in `@geekmidas/services` are **singletons**. `ServiceDiscovery.register()`
+(and `get()`) instantiates a service **once**, caches the instance in an internal
+`Map`, and returns that same instance for every subsequent request:
+
+```ts
+// ServiceDiscovery.register()
+if (this.instances.has(name)) {
+  return this.instances.get(name); // cached — register() does NOT run again
+}
+const instance = await service.register({ envParser, context: serviceContext });
+this.instances.set(name, instance);
+```
+
+The per-request logger, on the other hand, is **not** a singleton. On every request
+an adaptor builds a fresh child logger with request-specific bindings and stores it
+in `AsyncLocalStorage` via `runWithRequestContext`:
+
+```ts
+// e.g. HonoEndpointAdaptor
+const logger = endpoint.logger.child({
+  requestId,          // unique per request
+  endpoint, route, host, method, path,
+});
+
+return runWithRequestContext({ logger, requestId, startTime }, async () => {
+  const services = await serviceDiscovery.register(endpoint.services);
+  // ...handle request...
+});
+```
+
+### The bug
+
+`service.register()` runs **inside the first request's context**. If a service reads
+the logger **at registration time** and stores the concrete reference:
+
+```ts
+const databaseService = {
+  serviceName: 'database' as const,
+  register({ context }) {
+    const logger = context.getLogger(); // ❌ resolved ONCE, during request #1
+
+    return {
+      async query(sql: string) {
+        logger.debug({ sql }, 'Executing query'); // always request #1's logger
+      },
+    };
+  },
+} satisfies Service<'database', Database>;
+```
+
+…then `logger` is frozen to the **first** request's logger forever, because
+`register()` never runs again. Every later request reuses the cached service
+instance, so its logs carry the **first** request's `requestId` (and any user/session
+bindings).
+
+**Symptom:** logs make it look like the user who made the *first* request after a
+cold start is responsible for actions actually performed by *other* users on later
+requests. Request correlation, per-user log filtering, and audit trails are all
+silently wrong.
+
+This is an easy mistake to make because `register()` is handed a `context` object,
+and "grab the logger once and reuse it" looks reasonable — but it is incompatible
+with the singleton lifecycle.
+
+## Solution
+
+`serviceContext.getLogger()` returns a **stable, request-scoped proxy logger**
+instead of the raw logger. The proxy holds no logger of its own — on **every** log
+call it re-resolves the current request's logger from `AsyncLocalStorage`:
+
+```
+proxy.info('x')  →  asyncLocalStorage.getStore().logger.info('x')   // resolved at call time
+```
+
+Because resolution happens per call (not at capture time), capturing the logger once
+during `register()` is now **safe**: the single captured reference routes each call
+to whichever request is currently executing.
+
+```ts
+register({ context }) {
+  const logger = context.getLogger(); // ✅ now safe to capture — it's a live proxy
+
+  return {
+    async query(sql: string) {
+      logger.debug({ sql }, 'Executing query'); // logs to the CURRENT request
+    },
+  };
+}
+```
+
+### Child loggers compose correctly too
+
+`proxy.child(bindings)` returns **another** proxy carrying the bindings, applied lazily
+on top of the current request's logger at call time:
+
+```ts
+register({ context }) {
+  // Captured once. `{ svc: 'db' }` is the static part; the per-request bindings
+  // (requestId, user, ...) come from whichever base logger is current.
+  const logger = context.getLogger().child({ svc: 'db' });
+
+  return {
+    async query(sql: string) {
+      // request A → loggerA.child({ svc: 'db' }).debug(...)
+      // request B → loggerB.child({ svc: 'db' }).debug(...)
+      logger.debug({ sql }, 'Executing query');
+    },
+  };
+}
+```
+
+### Implementation
+
+See `createRequestScopedLogger` in
+[`src/context.ts`](../src/context.ts):
+
+- `getLogger()` still **throws eagerly** if called with no active request context,
+  preserving the "catch bugs early" contract.
+- The returned object is a shared, process-wide proxy. It carries no request state,
+  so sharing it across requests is safe — `AsyncLocalStorage` provides correct
+  per-async-context isolation, and each resolve/log call is synchronous (no `await`
+  between resolving and using the logger), so it is concurrency-safe.
+- Each `child()` call returns a new proxy that remembers its bindings and rebuilds
+  the child chain off the current base logger, memoised per underlying logger to
+  avoid rebuilding the chain on every log line.
+
+## Guidance for service authors
+
+- ✅ You **may** capture `context.getLogger()` (or a `.child()` of it) once in
+  `register()` and reuse it — it stays correct per request.
+- ✅ You **may** also call `context.getLogger()` inside each method; behaviour is
+  identical.
+- ⚠️ Do **not** wrap the proxy in something that snapshots a concrete logger, e.g.
+  `const real = someConcreteLogger; ...` outside the proxy. Resolution only stays
+  live while you go through the proxy returned by `getLogger()`/`.child()`.
+- ⚠️ Calling a log method outside any request context throws
+  (`called outside request context`). Guard background work with
+  `serviceContext.hasContext()` if it may run detached from a request.
+
+## Tests
+
+Regression coverage lives in
+[`src/__tests__/context.spec.ts`](../src/__tests__/context.spec.ts):
+
+- `captured-once logger follows each request (singleton service fix)` — a logger
+  captured during the first request still logs to the second request's logger.
+- `child loggers also follow the current request` — the same guarantee for
+  `.child()` proxies.
+- `should delegate to the current request logger` — basic delegation.

--- a/packages/services/src/__tests__/context.spec.ts
+++ b/packages/services/src/__tests__/context.spec.ts
@@ -1,6 +1,39 @@
+import type { Logger } from '@geekmidas/logger';
 import { ConsoleLogger } from '@geekmidas/logger/console';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { runWithRequestContext, serviceContext } from '../context';
+
+/** Minimal spy logger whose `child()` returns itself for easy assertions. */
+function makeSpyLogger(): Logger {
+	const logger: Logger = {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		child: vi.fn(() => logger),
+	};
+	return logger;
+}
+
+/**
+ * A logger that carries MORE than the base `Logger` interface: an extra method
+ * (`flush`) and a data property (`level`). Models a richer real-world logger
+ * (e.g. pino) so we can assert the request-scoped proxy forwards the full
+ * surface, not just the known log methods.
+ */
+type ExtendedLogger = Logger & {
+	flush: ReturnType<typeof vi.fn>;
+	level: string;
+};
+
+function makeExtendedSpyLogger(level = 'info'): ExtendedLogger {
+	const logger = makeSpyLogger() as ExtendedLogger;
+	logger.flush = vi.fn();
+	logger.level = level;
+	return logger;
+}
 
 describe('Request Context', () => {
 	const logger = new ConsoleLogger({ app: 'test' });
@@ -28,13 +61,156 @@ describe('Request Context', () => {
 				);
 			});
 
-			it('should return logger inside request context', async () => {
+			it('should delegate to the current request logger', async () => {
+				const requestLogger = makeSpyLogger();
 				await runWithRequestContext(
-					{ logger, requestId: 'test-id', startTime: Date.now() },
+					{
+						logger: requestLogger,
+						requestId: 'test-id',
+						startTime: Date.now(),
+					},
 					async () => {
-						expect(serviceContext.getLogger()).toBe(logger);
+						serviceContext.getLogger().info('hello');
 					},
 				);
+				expect(requestLogger.info).toHaveBeenCalledWith('hello');
+			});
+
+			it('captured-once logger follows each request (singleton service fix)', async () => {
+				// Mimic a singleton service that grabs the logger ONCE (during its
+				// one-time register) and reuses that reference for every request.
+				let captured: Logger | undefined;
+				const handle = (requestLogger: Logger) =>
+					runWithRequestContext(
+						{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+						async () => {
+							captured ??= serviceContext.getLogger();
+							captured.info('handled');
+						},
+					);
+
+				const first = makeSpyLogger();
+				const second = makeSpyLogger();
+				await handle(first);
+				await handle(second);
+
+				// Before the fix, the captured logger stayed bound to `first`, so
+				// `second` never saw the call.
+				expect(first.info).toHaveBeenCalledTimes(1);
+				expect(second.info).toHaveBeenCalledTimes(1);
+			});
+
+			it('child loggers also follow the current request', async () => {
+				let capturedChild: Logger | undefined;
+				const handle = (requestLogger: Logger) =>
+					runWithRequestContext(
+						{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+						async () => {
+							capturedChild ??= serviceContext
+								.getLogger()
+								.child({ scope: 'svc' });
+							capturedChild.info('scoped');
+						},
+					);
+
+				const first = makeSpyLogger();
+				const second = makeSpyLogger();
+				await handle(first);
+				await handle(second);
+
+				expect(first.child).toHaveBeenCalledWith({ scope: 'svc' });
+				expect(second.child).toHaveBeenCalledWith({ scope: 'svc' });
+				expect(first.info).toHaveBeenCalledWith('scoped');
+				expect(second.info).toHaveBeenCalledWith('scoped');
+			});
+
+			describe('forwards the full logger surface (logger with more)', () => {
+				it('forwards an extra method beyond the Logger interface', async () => {
+					const requestLogger = makeExtendedSpyLogger();
+					await runWithRequestContext(
+						{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+						async () => {
+							(serviceContext.getLogger() as ExtendedLogger).flush();
+						},
+					);
+					expect(requestLogger.flush).toHaveBeenCalledTimes(1);
+				});
+
+				it('re-resolves an extra method per request when captured once', async () => {
+					let captured: ExtendedLogger | undefined;
+					const handle = (requestLogger: Logger) =>
+						runWithRequestContext(
+							{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+							async () => {
+								captured ??= serviceContext.getLogger() as ExtendedLogger;
+								captured.flush();
+							},
+						);
+
+					const first = makeExtendedSpyLogger();
+					const second = makeExtendedSpyLogger();
+					await handle(first);
+					await handle(second);
+
+					expect(first.flush).toHaveBeenCalledTimes(1);
+					expect(second.flush).toHaveBeenCalledTimes(1);
+				});
+
+				it('forwards a data property as the current request logger value', async () => {
+					const captureLevel = (requestLogger: Logger) =>
+						runWithRequestContext(
+							{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+							async () => (serviceContext.getLogger() as ExtendedLogger).level,
+						);
+
+					const debugLogger = makeExtendedSpyLogger('debug');
+					const warnLogger = makeExtendedSpyLogger('warn');
+
+					expect(await captureLevel(debugLogger)).toBe('debug');
+					expect(await captureLevel(warnLogger)).toBe('warn');
+				});
+
+				it('detached method reference still targets the current request', async () => {
+					const requestLogger = makeExtendedSpyLogger();
+					await runWithRequestContext(
+						{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+						async () => {
+							const { info } = serviceContext.getLogger();
+							info('detached');
+						},
+					);
+					expect(requestLogger.info).toHaveBeenCalledWith('detached');
+				});
+
+				it('reflects underlying membership via the `in` operator', async () => {
+					const requestLogger = makeExtendedSpyLogger();
+					await runWithRequestContext(
+						{ logger: requestLogger, requestId: 'r', startTime: Date.now() },
+						async () => {
+							const proxy = serviceContext.getLogger();
+							expect('flush' in proxy).toBe(true);
+							expect('child' in proxy).toBe(true);
+							expect('nope' in proxy).toBe(false);
+						},
+					);
+				});
+
+				it('is not thenable (safe to return from async / await)', async () => {
+					await runWithRequestContext(
+						{
+							logger: makeExtendedSpyLogger(),
+							requestId: 'r',
+							startTime: Date.now(),
+						},
+						async () => {
+							const proxy = serviceContext.getLogger();
+							expect((proxy as { then?: unknown }).then).toBeUndefined();
+							// Awaiting a non-thenable yields the value itself rather than
+							// hanging or invoking a spurious `then`.
+							expect(await proxy).toBe(proxy);
+						},
+					);
+				});
 			});
 		});
 

--- a/packages/services/src/context.ts
+++ b/packages/services/src/context.ts
@@ -20,20 +20,114 @@ export interface RequestContextData {
 const requestContextStorage = new AsyncLocalStorage<RequestContextData>();
 
 /**
+ * Resolve the logger for the current request, or throw if there is none.
+ */
+function resolveRequestLogger(): Logger {
+	const store = requestContextStorage.getStore();
+	if (!store) {
+		throw new Error(
+			'ServiceContext.getLogger() called outside request context. ' +
+				'Ensure code runs within runWithRequestContext().',
+		);
+	}
+	return store.logger;
+}
+
+/**
+ * Create a Logger that re-resolves its underlying logger on every call instead
+ * of capturing it once.
+ *
+ * This is what makes it safe for a **singleton** service to grab the logger a
+ * single time (e.g. during `register()`, which `ServiceDiscovery` only runs
+ * once and then caches) and reuse that reference for every request: each log
+ * call resolves the *current* request's logger from `AsyncLocalStorage`, so
+ * requests no longer inherit the first request's logger (and its `requestId`,
+ * user bindings, etc.).
+ *
+ * Implemented as a `Proxy` rather than a fixed list of methods so it forwards
+ * the *entire* surface of whatever logger is supplied — including members
+ * beyond the base `Logger` interface (e.g. a richer pino-backed logger's
+ * `flush()` or `level`) and any methods added to `Logger` in the future.
+ *
+ * @param bindings - `child()` bindings applied, in order, on top of the
+ *   resolved logger before each call.
+ */
+function createRequestScopedLogger(bindings: object[] = []): Logger {
+	// Memoise the resolved (optionally child) logger per underlying base logger
+	// so we don't rebuild the child chain on every access within a request.
+	// Recomputed whenever the current request's logger changes — there is no
+	// await between the check and use, so this is safe under concurrency.
+	let cachedBase: Logger | undefined;
+	let cachedResolved: Logger | undefined;
+
+	const resolve = (): Logger => {
+		const base = resolveRequestLogger();
+		if (base !== cachedBase) {
+			cachedBase = base;
+			cachedResolved = bindings.reduce<Logger>(
+				(log, obj) => log.child(obj),
+				base,
+			);
+		}
+		return cachedResolved as Logger;
+	};
+
+	return new Proxy({} as Logger, {
+		get(_target, prop) {
+			// `child()` must stay request-scoped: return a new proxy carrying the
+			// extra binding, NOT the underlying logger's child (which would freeze
+			// to the current request).
+			if (prop === 'child') {
+				return (obj: object) => createRequestScopedLogger([...bindings, obj]);
+			}
+			// Never look like a thenable, and don't answer symbol/inspection probes
+			// (util.inspect, Symbol.toPrimitive, etc.) with bound functions.
+			if (prop === 'then' || typeof prop === 'symbol') {
+				return undefined;
+			}
+			const value = (resolve() as Record<string, unknown>)[prop];
+			// Functions are re-resolved at *call* time so detached references
+			// (`const info = logger.info`) still target the current request's
+			// logger. Non-function members (e.g. `level`) forward as their live
+			// value on the current request's logger.
+			return typeof value === 'function'
+				? (...args: unknown[]) =>
+						(resolve() as Record<string, (...a: unknown[]) => unknown>)[prop](
+							...args,
+						)
+				: value;
+		},
+		// Keep `'prop' in logger` / hasOwnProperty truthful against the underlying
+		// logger so feature-detection works.
+		has(_target, prop) {
+			if (prop === 'child') return true;
+			if (prop === 'then' || typeof prop === 'symbol') return false;
+			return prop in (resolve() as object);
+		},
+	});
+}
+
+/**
+ * Stable, process-wide request-scoped logger proxy. Shared across requests on
+ * purpose — it carries no request state itself, delegating to the current
+ * `AsyncLocalStorage` store on each call.
+ */
+const requestScopedLogger = createRequestScopedLogger();
+
+/**
  * ServiceContext implementation.
  * Singleton that reads from AsyncLocalStorage.
  * Methods throw if called outside a request context (catches bugs early).
  */
 export const serviceContext: ServiceContext = {
 	getLogger() {
-		const store = requestContextStorage.getStore();
-		if (!store) {
-			throw new Error(
-				'ServiceContext.getLogger() called outside request context. ' +
-					'Ensure code runs within runWithRequestContext().',
-			);
-		}
-		return store.logger;
+		// Throw eagerly if there is no context, preserving the "catch bugs early"
+		// contract for callers that read the logger at an unexpected time.
+		resolveRequestLogger();
+		// Return the shared proxy rather than the raw `store.logger`. A service
+		// that captures this once still logs against the correct per-request
+		// logger because the proxy re-resolves on every call.
+		return requestScopedLogger;
 	},
 
 	getRequestId() {

--- a/packages/services/src/types.ts
+++ b/packages/services/src/types.ts
@@ -9,6 +9,13 @@ import type { Logger } from '@geekmidas/logger';
 export interface ServiceContext {
 	/**
 	 * Get the current request's logger.
+	 *
+	 * Returns a **request-scoped proxy** that re-resolves the underlying logger
+	 * from AsyncLocalStorage on every call. This makes it safe for a singleton
+	 * service to capture the logger once (e.g. during `register()`) and reuse it
+	 * across requests — each log call routes to the current request's logger
+	 * instead of freezing the first request's logger.
+	 *
 	 * @throws Error if called outside a request context
 	 */
 	getLogger(): Logger;

--- a/packages/testkit/src/__tests__/requestContext.spec.ts
+++ b/packages/testkit/src/__tests__/requestContext.spec.ts
@@ -5,7 +5,7 @@ import {
 	ServiceDiscovery,
 	serviceContext,
 } from '@geekmidas/services';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
 	requestContextFixture,
 	runInRequestContext,
@@ -29,11 +29,15 @@ describe('runInRequestContext', () => {
 
 	test('uses caller-supplied logger and request id', async () => {
 		const logger = new ConsoleLogger({ app: 'spec' });
+		const infoSpy = vi.spyOn(logger, 'info');
 		const startTime = Date.now();
 
 		await runInRequestContext(
 			() => {
-				expect(serviceContext.getLogger()).toBe(logger);
+				// getLogger() returns a request-scoped proxy that delegates to the
+				// supplied logger rather than being the same instance.
+				serviceContext.getLogger().info('hi');
+				expect(infoSpy).toHaveBeenCalledWith('hi');
 				expect(serviceContext.getRequestId()).toBe('req-42');
 				expect(serviceContext.getRequestStartTime()).toBe(startTime);
 			},


### PR DESCRIPTION
serviceContext.getLogger() now returns a request-scoped proxy that re-resolves the current request's logger from AsyncLocalStorage on every call, instead of returning the raw logger.

Services are singletons: ServiceDiscovery.register() runs once and caches the instance. Since the first register() runs inside the first request's context, a service that captured context.getLogger() at register time froze the first request's logger forever — every later request then logged with the first request's requestId and user bindings.

The proxy makes capturing the logger once (in register, or via .child()) safe: each log call routes to whichever request is currently executing. child() proxies compose static bindings over the current base logger. getLogger() still throws eagerly outside a request context.

Updated identity (toBe) assertions across services/testkit/constructs to behavioral delegation checks, and added regression coverage for the singleton-capture and child-proxy cases. Documented the problem and fix in packages/services/docs/request-scoped-logging.md.