### PR TITLE
feat(cli): add `gkm test --auto-setup` to self-provision a stage in CI

### DIFF
--- a/.changeset/gkm-test-auto-setup.md
+++ b/.changeset/gkm-test-auto-setup.md
@@ -1,0 +1,16 @@
+---
+'@geekmidas/cli': minor
+---
+
+feat(cli): add `gkm test --auto-setup` to self-provision a stage in CI
+
+`gkm test` previously required a local secrets file and the matching `~/.gkm`
+encryption key, so it could not run on a fresh CI checkout (where `.env` and
+`.gkm/` are gitignored).
+
+With `--auto-setup` (or the `GKM_AUTO_SETUP` env var), `gkm test` now
+regenerates a fresh stage from the committed `gkm.config.ts` when no secrets
+exist — minting service credentials and a local key, then starting Docker with
+those values. For tests this is safe because the credentials are ephemeral local
+service passwords used to bring up the matching containers. The behavior is a
+no-op when secrets already exist and is scoped to `gkm test` only.

--- a/apps/docs/packages/cli.md
+++ b/apps/docs/packages/cli.md
@@ -413,6 +413,9 @@ gkm test --stage staging
 
 # Filter tests by pattern
 gkm test users.spec.ts
+
+# Self-provision the stage when none exists (CI)
+gkm test --run --auto-setup
 ```
 
 **Options:**
@@ -424,9 +427,24 @@ gkm test users.spec.ts
 | `--watch` | Enable watch mode |
 | `--coverage` | Generate coverage report |
 | `--ui` | Open Vitest UI |
+| `--auto-setup` | Generate a fresh stage (secrets + key) from `gkm.config.ts` when none exists (also via `GKM_AUTO_SETUP`) |
 | `[pattern]` | Pattern to filter tests |
 
 The test command decrypts secrets from `.gkm/secrets/{stage}.json` and injects them as environment variables before running Vitest.
+
+#### Running in CI
+
+A fresh CI checkout has no `.gkm/secrets/{stage}.json` and no encryption key (both `.env` and `.gkm/` are typically gitignored), so `gkm test` has nothing to decrypt. Pass `--auto-setup` (or set `GKM_AUTO_SETUP=1`) to regenerate the stage from the committed `gkm.config.ts`:
+
+```yaml
+# GitHub Actions
+env:
+  GKM_AUTO_SETUP: '1'
+steps:
+  - run: gkm test --run
+```
+
+When no secrets exist for the stage, `gkm test` generates fresh service credentials and a local encryption key, then starts Docker with those values before running Vitest. This is safe for tests because the credentials are ephemeral local service passwords used to bring up the matching containers — nothing real is committed. The behavior is a no-op when secrets already exist and is scoped to `gkm test` only.
 
 ### Secrets Management
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -619,6 +619,7 @@ gkm test [options]
 - `--watch`: Enable watch mode
 - `--coverage`: Generate coverage report
 - `--ui`: Open Vitest UI
+- `--auto-setup`: Generate a fresh stage (secrets + key) from `gkm.config.ts` when none exists — for CI (also via `GKM_AUTO_SETUP`)
 - `--pattern <pattern>`: Pattern to filter tests
 
 **What it does:**
@@ -645,6 +646,19 @@ gkm test --coverage
 > **Why not `docker compose up` directly?**
 >
 > `gkm dev` and `gkm test` decrypt your secrets and pass them as environment variables to `docker compose up`, ensuring credentials and ports are consistent. Running `docker compose up` directly skips this — variables like `${POSTGRES_USER:-postgres}` fall back to defaults that won't match your project credentials.
+
+> **Running in CI:**
+>
+> A fresh CI checkout has no `.gkm/secrets/{stage}.json` and no encryption key (`.env` and `.gkm/` are typically gitignored), so there's nothing to decrypt. Pass `--auto-setup` (or set `GKM_AUTO_SETUP=1`) to regenerate the stage from the committed `gkm.config.ts`:
+>
+> ```yaml
+> env:
+>   GKM_AUTO_SETUP: '1'
+> steps:
+>   - run: gkm test --run
+> ```
+>
+> When no secrets exist for the stage, `gkm test` generates fresh service credentials and a local key, then starts Docker with those values. This is safe for tests — the credentials are ephemeral local service passwords used to bring up the matching containers, so nothing real is committed. It's a no-op when secrets already exist and is scoped to `gkm test` only.
 
 ### `gkm secrets:init`
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -236,6 +236,10 @@ program
 	.option('--watch', 'Enable watch mode')
 	.option('--coverage', 'Generate coverage report')
 	.option('--ui', 'Open Vitest UI')
+	.option(
+		'--auto-setup',
+		'Generate a fresh stage (secrets + key) from the workspace config when none exists (for CI; also via GKM_AUTO_SETUP)',
+	)
 	.argument('[pattern]', 'Pattern to filter tests')
 	.action(async (pattern: string | undefined, options: TestOptions) => {
 		try {

--- a/packages/cli/src/setup/__tests__/auto-setup.spec.ts
+++ b/packages/cli/src/setup/__tests__/auto-setup.spec.ts
@@ -1,0 +1,147 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readStageSecrets, secretsExist } from '../../secrets/storage.js';
+import type { NormalizedWorkspace } from '../../workspace/types.js';
+import { createFreshWorkspaceSecrets, ensureStageSecrets } from '../index.js';
+
+function createWorkspace(
+	overrides: Partial<NormalizedWorkspace> = {},
+): NormalizedWorkspace {
+	return {
+		name: 'test-project',
+		root: '/tmp/test-project',
+		apps: {
+			api: {
+				type: 'backend',
+				port: 3000,
+				root: '/tmp/test-project/apps/api',
+				packageName: '@test/api',
+				routes: './src/endpoints/**/*.ts',
+				dependencies: [],
+			},
+		},
+		services: { db: true },
+		deploy: {},
+		shared: {},
+		secrets: {},
+		...overrides,
+	} as NormalizedWorkspace;
+}
+
+describe('createFreshWorkspaceSecrets', () => {
+	it('generates postgres credentials when db service is enabled', () => {
+		const secrets = createFreshWorkspaceSecrets(
+			'development',
+			createWorkspace(),
+		);
+
+		expect(secrets.stage).toBe('development');
+		expect(secrets.services.postgres).toBeDefined();
+		expect(secrets.services.postgres?.password).toBeTruthy();
+		expect(secrets.urls.DATABASE_URL).toContain('postgresql://');
+	});
+
+	it('generates a randomized password each call', () => {
+		const a = createFreshWorkspaceSecrets('development', createWorkspace());
+		const b = createFreshWorkspaceSecrets('development', createWorkspace());
+
+		expect(a.services.postgres?.password).not.toBe(
+			b.services.postgres?.password,
+		);
+	});
+
+	it('adds single-app custom secrets', () => {
+		const secrets = createFreshWorkspaceSecrets(
+			'development',
+			createWorkspace(),
+		);
+
+		expect(secrets.custom.NODE_ENV).toBe('development');
+		expect(secrets.custom.JWT_SECRET).toBeTruthy();
+	});
+});
+
+describe('ensureStageSecrets', () => {
+	let testDir: string;
+	const originalGkmConfigPath = process.env.GKM_CONFIG_PATH;
+
+	beforeEach(() => {
+		testDir = join(
+			tmpdir(),
+			`gkm-auto-setup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(testDir, { recursive: true });
+
+		// Minimal single-app workspace config with a db service.
+		writeFileSync(
+			join(testDir, 'gkm.config.ts'),
+			`import { defineWorkspace } from '@geekmidas/cli/config';
+
+export default defineWorkspace({
+  name: 'test-workspace',
+  apps: {
+    api: {
+      type: 'backend',
+      path: 'apps/api',
+      port: 3001,
+      routes: './src/endpoints/**/*.ts',
+      envParser: './src/config/env#envParser',
+      logger: './src/config/logger#logger',
+    },
+  },
+  services: { db: true },
+});
+`,
+		);
+		const apiDir = join(testDir, 'apps', 'api');
+		mkdirSync(apiDir, { recursive: true });
+		writeFileSync(
+			join(apiDir, 'package.json'),
+			JSON.stringify({ name: '@test/api', version: '0.0.1' }),
+		);
+
+		process.env.GKM_CONFIG_PATH = join(testDir, 'gkm.config.ts');
+	});
+
+	afterEach(async () => {
+		if (originalGkmConfigPath === undefined) {
+			delete process.env.GKM_CONFIG_PATH;
+		} else {
+			process.env.GKM_CONFIG_PATH = originalGkmConfigPath;
+		}
+
+		await rm(testDir, { recursive: true, force: true });
+		// writeStageSecrets mints a key at ~/.gkm/{basename(root)}
+		await rm(join(homedir(), '.gkm', basename(testDir)), {
+			recursive: true,
+			force: true,
+		});
+	});
+
+	it('generates a decryptable stage when none exists', async () => {
+		expect(secretsExist('development', testDir)).toBe(false);
+
+		const generated = await ensureStageSecrets('development', testDir);
+
+		expect(generated).toBe(true);
+		expect(secretsExist('development', testDir)).toBe(true);
+
+		// Round-trips through the keystore the same way `gkm test` reads it.
+		const read = await readStageSecrets('development', testDir);
+		expect(read?.services.postgres).toBeDefined();
+	});
+
+	it('is a no-op when secrets already exist', async () => {
+		await ensureStageSecrets('development', testDir);
+		const before = await readStageSecrets('development', testDir);
+
+		const generated = await ensureStageSecrets('development', testDir);
+
+		expect(generated).toBe(false);
+		const after = await readStageSecrets('development', testDir);
+		expect(after).toEqual(before);
+	});
+});

--- a/packages/cli/src/setup/index.ts
+++ b/packages/cli/src/setup/index.ts
@@ -288,13 +288,16 @@ export function reconcileSecrets(
 }
 
 /**
- * Generate fresh secrets for the workspace.
+ * Build a fresh StageSecrets object for a workspace: service credentials,
+ * connection URLs, and custom secrets. Pure — does not write to disk or touch
+ * SSM. Service passwords are freshly randomized, so the result must be the same
+ * one used to start the matching Docker containers.
+ * @internal Exported for reuse by `gkm test` auto-setup.
  */
-async function generateFreshSecrets(
+export function createFreshWorkspaceSecrets(
 	stage: string,
 	workspace: NormalizedWorkspace,
-	options: SetupOptions,
-) {
+): StageSecrets {
 	// Determine services from workspace config
 	const serviceNames: ComposeServiceName[] = [];
 	if (workspace.services.db) serviceNames.push('postgres');
@@ -313,8 +316,7 @@ async function generateFreshSecrets(
 	// Generate fullstack-aware custom secrets
 	const isMultiApp = Object.keys(workspace.apps).length > 1;
 	if (isMultiApp) {
-		const customSecrets = generateFullstackCustomSecrets(workspace);
-		secrets.custom = customSecrets;
+		secrets.custom = generateFullstackCustomSecrets(workspace);
 	} else {
 		secrets.custom = {
 			NODE_ENV: 'development',
@@ -323,6 +325,44 @@ async function generateFreshSecrets(
 			JWT_SECRET: `dev-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 		};
 	}
+
+	return secrets;
+}
+
+/**
+ * Ensure a usable secret set exists for a stage, generating a fresh one from the
+ * workspace config when none is present. No-op if secrets already exist.
+ *
+ * Powers `gkm test --auto-setup` / `GKM_AUTO_SETUP`: CI can run without a
+ * committed secrets file or a shared encryption key — the stage is regenerated
+ * from the committed `gkm.config.ts`, and `writeStageSecrets` mints a local key.
+ *
+ * @returns true if fresh secrets were generated, false if existing ones were kept
+ */
+export async function ensureStageSecrets(
+	stage: string,
+	cwd: string = process.cwd(),
+): Promise<boolean> {
+	const { workspace } = await loadWorkspaceConfig(cwd);
+
+	if (secretsExist(stage, workspace.root)) {
+		return false;
+	}
+
+	const secrets = createFreshWorkspaceSecrets(stage, workspace);
+	await writeStageSecrets(secrets, workspace.root);
+	return true;
+}
+
+/**
+ * Generate fresh secrets for the workspace.
+ */
+async function generateFreshSecrets(
+	stage: string,
+	workspace: NormalizedWorkspace,
+	options: SetupOptions,
+) {
+	const secrets = createFreshWorkspaceSecrets(stage, workspace);
 
 	// Write secrets
 	await writeStageSecrets(secrets, workspace.root);

--- a/packages/cli/src/test/index.ts
+++ b/packages/cli/src/test/index.ts
@@ -21,6 +21,12 @@ export interface TestOptions {
 	ui?: boolean;
 	/** Pattern to filter tests */
 	pattern?: string;
+	/**
+	 * Generate a fresh stage (secrets + encryption key) from the workspace config
+	 * when none exists, instead of requiring committed secrets / a shared key.
+	 * Intended for CI. Also enabled by the GKM_AUTO_SETUP env var.
+	 */
+	autoSetup?: boolean;
 }
 
 /**
@@ -32,6 +38,17 @@ export async function testCommand(options: TestOptions = {}): Promise<void> {
 	const cwd = process.cwd();
 
 	console.log(`\n🧪 Running tests with ${stage} environment...\n`);
+
+	// 0. Auto-setup (CI): regenerate a fresh stage from the workspace config when
+	//    none exists, so tests run without committed secrets or a shared key.
+	const autoSetup = options.autoSetup || Boolean(process.env.GKM_AUTO_SETUP);
+	if (autoSetup) {
+		const { ensureStageSecrets } = await import('../setup/index.js');
+		const generated = await ensureStageSecrets(stage, cwd);
+		if (generated) {
+			console.log(`  🔐 Generated fresh ${stage} secrets (auto-setup)`);
+		}
+	}
 
 	// 1. Load .env files
 	const defaultEnv = loadEnvFiles('.env');


### PR DESCRIPTION
## Problem

`gkm test` requires a local `.gkm/secrets/{stage}.json` file **and** the matching encryption key at `~/.gkm/{project}/{stage}.key`. On a fresh CI checkout neither exists — `.env`, `.gkm/`, and `docker/.env` are all (correctly) gitignored — so `gkm test` can't run.

## Approach

For tests, the "secrets" are just local Docker service credentials (random postgres/redis/etc. passwords), not real secrets — the same values are used to start the containers and run the tests. So CI doesn't need a committed secrets file or a shared key: it can regenerate the whole stage from the committed `gkm.config.ts`.

This adds an **opt-in** bootstrap, scoped to `gkm test` only (`dev`/`build`/`deploy` untouched):

- CLI flag: `gkm test --auto-setup`
- Env var: `GKM_AUTO_SETUP=1` (ideal for CI)

When triggered and the stage's secrets are missing, `gkm test` generates a fresh stage from the workspace config (minting service credentials + a local key via `writeStageSecrets`), then proceeds as normal (starts Docker with those values, runs vitest). No-op when secrets already exist.

## Changes

- `setup/index.ts` — extracted pure `createFreshWorkspaceSecrets(stage, workspace)` out of `generateFreshSecrets`; added `ensureStageSecrets(stage, cwd)` (generates+writes only when missing, returns whether it generated)
- `test/index.ts` — new step 0: when `options.autoSetup || process.env.GKM_AUTO_SETUP`, calls `ensureStageSecrets` before loading credentials; added `autoSetup` to `TestOptions`
- `index.ts` — registered the `--auto-setup` flag on the `test` command
- `setup/__tests__/auto-setup.spec.ts` — 5 tests (fresh-secrets generation + generate-when-missing / no-op-when-present, round-tripping through the keystore)
- Changeset: **minor** bump for `@geekmidas/cli`

## CI usage

```yaml
env:
  GKM_AUTO_SETUP: '1'
steps:
  - run: gkm test --run
```

No committed secrets, no shared key, no `.env` needed — the committed `gkm.config.ts` + `docker-compose.yml` are all CI requires.

## Testing

- New: 5 tests in `auto-setup.spec.ts` pass
- Existing setup + test suites pass (57 tests)
- Biome clean; `tsc` reports only pre-existing unrelated errors (`deploy/domain.ts`, `dev/index.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)