### PR TITLE
feat(constructs): allow endpoint handlers to return output schema's input type

### DIFF
--- a/.changeset/endpoint-handler-input-type.md
+++ b/.changeset/endpoint-handler-input-type.md
@@ -1,0 +1,17 @@
+---
+'@geekmidas/schema': patch
+'@geekmidas/constructs': patch
+---
+
+feat(constructs): allow endpoint handlers to return the output schema's input type
+
+Endpoint handlers previously had to return the output schema's *parsed* type
+(`InferStandardSchema`). When an output schema coerces its value (e.g. a `Date`
+serialized to an ISO `string`, or an applied default), that forced handlers to
+pre-coerce values themselves even though the schema would do it on the way out.
+
+A new `InferStandardSchemaInput` type is added to `@geekmidas/schema`, exposing a
+Standard Schema's *input* type (`StandardSchemaV1.InferInput`). `Endpoint`'s
+handler return type now uses it, so handlers may return the looser pre-coercion
+input while consumers (`EndpointOutput` and the generated client) still see the
+narrower parsed output type.

--- a/packages/constructs/src/endpoints/Endpoint.ts
+++ b/packages/constructs/src/endpoints/Endpoint.ts
@@ -9,6 +9,7 @@ import type { RateLimitConfig } from '@geekmidas/rate-limit';
 import type {
 	InferComposableStandardSchema,
 	InferStandardSchema,
+	InferStandardSchemaInput,
 } from '@geekmidas/schema';
 import {
 	convertSchemaWithComponents,
@@ -367,11 +368,12 @@ export class Endpoint<
 		>,
 		response: ResponseBuilder,
 	): OutSchema extends StandardSchemaV1
-		?
-				| InferStandardSchema<OutSchema>
-				| ResponseWithMetadata<InferStandardSchema<OutSchema>>
-				| Promise<InferStandardSchema<OutSchema>>
-				| Promise<ResponseWithMetadata<InferStandardSchema<OutSchema>>>
+		? // Handler produces the output schema's INPUT type (the schema
+			// may coerce it on the way out — see EndpointHandler).
+				| InferStandardSchemaInput<OutSchema>
+				| ResponseWithMetadata<InferStandardSchemaInput<OutSchema>>
+				| Promise<InferStandardSchemaInput<OutSchema>>
+				| Promise<ResponseWithMetadata<InferStandardSchemaInput<OutSchema>>>
 		:
 				| any
 				| ResponseWithMetadata<any>
@@ -1241,11 +1243,15 @@ export type EndpointHandler<
 	>,
 	response: ResponseBuilder,
 ) => OutSchema extends StandardSchemaV1
-	?
-			| InferStandardSchema<OutSchema>
-			| ResponseWithMetadata<InferStandardSchema<OutSchema>>
-			| Promise<InferStandardSchema<OutSchema>>
-			| Promise<ResponseWithMetadata<InferStandardSchema<OutSchema>>>
+	? // The handler must produce the schema's INPUT type — the output
+		// schema is allowed to coerce it (e.g. a `Date` → ISO `string`),
+		// so the handler may return the looser input while consumers
+		// (EndpointOutput / the generated client) still see the parsed
+		// output type.
+			| InferStandardSchemaInput<OutSchema>
+			| ResponseWithMetadata<InferStandardSchemaInput<OutSchema>>
+			| Promise<InferStandardSchemaInput<OutSchema>>
+			| Promise<ResponseWithMetadata<InferStandardSchemaInput<OutSchema>>>
 	:
 			| unknown
 			| ResponseWithMetadata<unknown>

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,4 +11,5 @@ export type {
 	ComposableStandardSchema,
 	InferComposableStandardSchema,
 	InferStandardSchema,
+	InferStandardSchemaInput,
 } from './types';

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -4,6 +4,20 @@ export type InferStandardSchema<T> = T extends StandardSchemaV1
 	? StandardSchemaV1.InferOutput<T>
 	: never;
 
+/**
+ * The *input* type a Standard Schema accepts (before any transform/coercion),
+ * as opposed to {@link InferStandardSchema} which is the output type.
+ *
+ * Use this for the value a producer must HAND TO the schema (e.g. an endpoint
+ * handler's return that will be parsed by its output schema): the schema may
+ * coerce it (a `Date` → an ISO `string`, a default applied, etc.), so the
+ * producer should be allowed to supply the looser input type while consumers
+ * still see the narrower output type.
+ */
+export type InferStandardSchemaInput<T> = T extends StandardSchemaV1
+	? StandardSchemaV1.InferInput<T>
+	: never;
+
 export type ComposableStandardSchema =
 	| StandardSchemaV1
 	| {


### PR DESCRIPTION
## Summary

Endpoint handlers previously had to return the output schema's **parsed** type (`InferStandardSchema`). When an output schema coerces its value (e.g. a `Date` serialized to an ISO `string`, or an applied default), that forced handlers to pre-coerce values themselves even though the schema does it on the way out.

This change adds a new `InferStandardSchemaInput` type to `@geekmidas/schema` (exposing `StandardSchemaV1.InferInput`) and switches `Endpoint`'s handler return type to use it. Handlers may now return the looser pre-coercion **input** type, while consumers (`EndpointOutput` and the generated client) still see the narrower parsed **output** type.

## Changes

- **`@geekmidas/schema`** — new exported `InferStandardSchemaInput<T>` type.
- **`@geekmidas/constructs`** — `Endpoint` handler / `EndpointHandler` return types use `InferStandardSchemaInput` instead of `InferStandardSchema`.
- Changeset (`patch` for both packages — non-breaking type widening).

## Testing

- `pnpm run build` — pass
- `pnpm run lint` — pass
- `pnpm run test:once` — all 862 unit tests pass (3 DB integration test files were skipped locally; they require the docker-compose Postgres stack which CI provisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)