### PR TITLE
feat(audit): add Knex audit storage

### DIFF
--- a/.changeset/tidy-melons-smoke.md
+++ b/.changeset/tidy-melons-smoke.md
@@ -1,0 +1,17 @@
+---
+'@geekmidas/audit': minor
+---
+
+Add Knex audit storage via a new `@geekmidas/audit/knex` entry point.
+
+`KnexAuditStorage` mirrors `KyselyAuditStorage` — same config (`db`,
+`tableName`, `databaseServiceName`, `autoId`), same `query()`/`count()`
+filters, and the same transaction semantics. A `withAuditableTransaction`
+helper is included; passing an existing transaction reuses it instead of
+opening a savepoint, so audits roll back with the outer transaction.
+
+Because it implements `withTransaction()`, `getDatabase()` and
+`databaseServiceName`, endpoints wrap handlers and audit flushes in a single
+transaction with Knex just as they do with Kysely.
+
+`knex` is an optional peer dependency, so Kysely-only users are unaffected.

--- a/apps/docs/packages/audit.md
+++ b/apps/docs/packages/audit.md
@@ -12,7 +12,7 @@ pnpm add @geekmidas/audit
 
 - Type-safe audit actions with compile-time validation
 - Transactional support for atomic database writes
-- Pluggable storage backends (Kysely implementation included)
+- Pluggable storage backends (Kysely and Knex implementations included)
 - Actor tracking (users, services, systems)
 - Rich metadata support (request context, entity references)
 - Query and filtering capabilities
@@ -21,6 +21,7 @@ pnpm add @geekmidas/audit
 
 - `/` - Core types, Auditor interface, and DefaultAuditor
 - `/kysely` - KyselyAuditStorage and withAuditableTransaction
+- `/knex` - KnexAuditStorage and withAuditableTransaction
 - `/memory` - InMemoryAuditStorage for development and testing
 - `/cache` - CacheAuditStorage using @geekmidas/cache backends
 
@@ -48,6 +49,22 @@ const storage = new KyselyAuditStorage<Database>({
   tableName: 'audit_logs',
 });
 ```
+
+Or, with Knex:
+
+```typescript
+import { KnexAuditStorage } from '@geekmidas/audit/knex';
+
+const storage = new KnexAuditStorage({
+  db: knexDb,
+  tableName: 'audit_logs',
+});
+```
+
+`KnexAuditStorage` mirrors `KyselyAuditStorage`: same config options, same
+query filters, and the same transaction semantics. Column names are camelCase
+in both; pair Knex with `knexSnakeCaseMappers()` if your columns are
+snake_case.
 
 ### Create and Use Auditor
 
@@ -102,7 +119,7 @@ const result = await withAuditableTransaction(
 
 ## Querying Audit Records
 
-The `query()` and `count()` methods on audit storage let you search, filter, and paginate audit records. Both `KyselyAuditStorage` and `CacheAuditStorage` implement these methods.
+The `query()` and `count()` methods on audit storage let you search, filter, and paginate audit records. `KyselyAuditStorage`, `KnexAuditStorage`, and `CacheAuditStorage` all implement these methods.
 
 ### Basic Query
 
@@ -262,7 +279,7 @@ const endpoint = e
 
 ### Transaction Coordination
 
-When the audit storage uses the same database as the endpoint (via `KyselyAuditStorage`), the framework automatically wraps the handler and audit flush in a single database transaction. Both data changes and audit records commit or roll back together:
+When the audit storage uses the same database as the endpoint (via `KyselyAuditStorage` or `KnexAuditStorage`), the framework automatically wraps the handler and audit flush in a single database transaction. Both data changes and audit records commit or roll back together:
 
 ```typescript
 import { KyselyAuditStorage } from '@geekmidas/audit/kysely';

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -10,7 +10,7 @@
 
 - **Type-safe Audit Actions**: Define audit types with TypeScript for compile-time safety
 - **Transactional Support**: Flush audits atomically within database transactions
-- **Flexible Storage**: Pluggable storage interface (Kysely, in-memory, cache)
+- **Flexible Storage**: Pluggable storage interface (Kysely, Knex, in-memory, cache)
 - **Actor Tracking**: Record who performed each action (users, services, systems)
 - **Rich Metadata**: Attach request context, entity references, and custom data
 - **Query Support**: Query audit logs with filters, pagination, and sorting
@@ -66,6 +66,17 @@ interface Database {
 
 const storage = new KyselyAuditStorage<Database>({
   db: kyselyDb,
+  tableName: 'audit_logs',
+});
+```
+
+**For Production (KnexAuditStorage):**
+
+```typescript
+import { KnexAuditStorage } from '@geekmidas/audit/knex';
+
+const storage = new KnexAuditStorage({
+  db: knexDb,
   tableName: 'audit_logs',
 });
 ```
@@ -275,6 +286,67 @@ const count = await storage.count({
 });
 ```
 
+### `KnexAuditStorage`
+
+Built-in Knex storage implementation. It mirrors `KyselyAuditStorage` — same
+config, same `query()`/`count()` filters, same transaction semantics:
+
+```typescript
+import { KnexAuditStorage } from '@geekmidas/audit/knex';
+
+const storage = new KnexAuditStorage({
+  db: knexDb,
+  tableName: 'audit_logs',
+  databaseServiceName: 'database', // Optional: for automatic transaction injection
+  autoId: false, // Optional: let database generate IDs
+});
+
+const audits = await storage.query({
+  type: 'user.created',
+  actorId: 'user-123',
+  from: new Date('2024-01-01'),
+  limit: 100,
+  orderBy: 'timestamp',
+  orderDirection: 'desc',
+});
+
+const count = await storage.count({
+  type: ['user.created', 'user.updated'],
+  actorId: 'user-123',
+});
+```
+
+Column names are camelCase, matching the Kysely storage. If your database uses
+snake_case columns, configure Knex with a case mapper:
+
+```typescript
+import { knexSnakeCaseMappers } from 'objection';
+
+const knexDb = knex({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+  ...knexSnakeCaseMappers(),
+});
+```
+
+Transactions work the same way as the Kysely storage:
+
+```typescript
+import { withAuditableTransaction } from '@geekmidas/audit/knex';
+
+const user = await withAuditableTransaction(knexDb, auditor, async (trx) => {
+  const [user] = await trx('users').insert(data).returning('*');
+
+  auditor.audit('user.created', { userId: user.id, email: user.email });
+
+  return user;
+});
+// Audits are flushed inside the transaction, before it commits
+```
+
+Passing a transaction as the first argument reuses it instead of opening a
+savepoint, so audits roll back with the outer transaction.
+
 ### `InMemoryAuditStorage`
 
 Convenience wrapper around `CacheAuditStorage` with `InMemoryCache`. Useful for testing and development:
@@ -332,7 +404,7 @@ await storage.clear();
 
 ## Database Schema
 
-Create an `audit_logs` table for `KyselyAuditStorage`:
+Create an `audit_logs` table for `KyselyAuditStorage` or `KnexAuditStorage`:
 
 ```sql
 CREATE TABLE audit_logs (

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -23,6 +23,16 @@
 				"default": "./dist/kysely.cjs"
 			}
 		},
+		"./knex": {
+			"import": {
+				"types": "./dist/knex.d.mts",
+				"default": "./dist/knex.mjs"
+			},
+			"require": {
+				"types": "./dist/knex.d.cts",
+				"default": "./dist/knex.cjs"
+			}
+		},
 		"./memory": {
 			"import": {
 				"types": "./dist/memory.d.mts",
@@ -59,7 +69,8 @@
 	"peerDependencies": {
 		"@geekmidas/cache": "workspace:^",
 		"@geekmidas/schema": "workspace:^",
-		"kysely": ">=0.28.2 <0.30.0"
+		"kysely": ">=0.28.2 <0.30.0",
+		"knex": ">=3.0.0 <4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@geekmidas/cache": {
@@ -70,6 +81,9 @@
 		},
 		"kysely": {
 			"optional": true
+		},
+		"knex": {
+			"optional": true
 		}
 	},
 	"devDependencies": {
@@ -77,6 +91,7 @@
 		"@geekmidas/schema": "workspace:^",
 		"kysely": "~0.29.4",
 		"pg": "~8.16.0",
-		"@types/pg": "~8.15.6"
+		"@types/pg": "~8.15.6",
+		"knex": "~3.1.0"
 	}
 }

--- a/packages/audit/src/__tests__/KnexAuditStorage.integration.spec.ts
+++ b/packages/audit/src/__tests__/KnexAuditStorage.integration.spec.ts
@@ -1,0 +1,739 @@
+import knexFactory, { type Knex } from 'knex';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from 'vitest';
+import { TEST_DATABASE_CONFIG } from '../../../testkit/test/globalSetup';
+import { DefaultAuditor } from '../DefaultAuditor';
+import {
+	type AuditLogTable,
+	KnexAuditStorage,
+	withAuditableTransaction,
+} from '../knex';
+import type { AuditableAction, AuditRecord } from '../types';
+
+// Use unique table names to avoid conflicts with parallel tests
+const AUDIT_TABLE = 'audit_knex_int_logs' as const;
+const AUTO_ID_TABLE = 'audit_knex_int_auto' as const;
+const USERS_TABLE = 'audit_knex_int_users' as const;
+
+// Define test audit actions
+type TestAuditAction =
+	| AuditableAction<'user.created', { userId: number; email: string }>
+	| AuditableAction<'user.updated', { userId: number; changes: string[] }>
+	| AuditableAction<'user.deleted', { userId: number }>;
+
+function auditColumns(db: Knex, table: Knex.CreateTableBuilder): void {
+	table.string('type').notNullable();
+	table.string('operation').notNullable();
+	table.string('table');
+	table.string('entityId');
+	table.jsonb('oldValues');
+	table.jsonb('newValues');
+	table.jsonb('payload');
+	table.timestamp('timestamp').notNullable().defaultTo(db.fn.now());
+	table.string('actorId');
+	table.string('actorType');
+	table.jsonb('actorData');
+	table.jsonb('metadata');
+}
+
+describe('KnexAuditStorage Integration Tests', () => {
+	let db: Knex;
+	let storage: KnexAuditStorage;
+
+	beforeAll(async () => {
+		db = knexFactory({
+			client: 'pg',
+			connection: {
+				...TEST_DATABASE_CONFIG,
+				database: 'postgres',
+			},
+		});
+
+		// Recreate tables so a crashed previous run cannot leak state
+		await db.schema.dropTableIfExists(AUDIT_TABLE);
+		await db.schema.dropTableIfExists(AUTO_ID_TABLE);
+		await db.schema.dropTableIfExists(USERS_TABLE);
+
+		// Audit table with client-supplied IDs
+		await db.schema.createTable(AUDIT_TABLE, (table) => {
+			table.string('id', 32).primary();
+			auditColumns(db, table);
+		});
+
+		// Audit table where the database generates IDs
+		await db.schema.createTable(AUTO_ID_TABLE, (table) => {
+			table.uuid('id').primary().defaultTo(db.raw('gen_random_uuid()'));
+			auditColumns(db, table);
+		});
+
+		// Users table for testing audit integration
+		await db.schema.createTable(USERS_TABLE, (table) => {
+			table.increments('id').primary();
+			table.string('name').notNullable();
+			table.string('email').notNullable().unique();
+		});
+
+		storage = new KnexAuditStorage({
+			db,
+			tableName: AUDIT_TABLE,
+		});
+	});
+
+	afterEach(async () => {
+		// Clean up data after each test
+		await db(AUDIT_TABLE).del();
+		await db(AUTO_ID_TABLE).del();
+		await db(USERS_TABLE).del();
+	});
+
+	afterAll(async () => {
+		// Drop tables and close connection
+		await db.schema.dropTableIfExists(AUDIT_TABLE);
+		await db.schema.dropTableIfExists(AUTO_ID_TABLE);
+		await db.schema.dropTableIfExists(USERS_TABLE);
+		await db.destroy();
+	});
+
+	describe('write', () => {
+		it('should write audit records to database', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-123', type: 'user' },
+				storage,
+				metadata: { requestId: 'req-456' },
+			});
+
+			auditor.audit('user.created', { userId: 1, email: 'test@example.com' });
+
+			await auditor.flush();
+
+			// Verify record was written
+			const records = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+
+			expect(records).toHaveLength(1);
+			expect(records[0].type).toBe('user.created');
+			expect(records[0].operation).toBe('CUSTOM');
+			expect(records[0].actorId).toBe('user-123');
+			expect(records[0].actorType).toBe('user');
+			expect(records[0].payload).toEqual({
+				userId: 1,
+				email: 'test@example.com',
+			});
+			expect(records[0].metadata).toEqual({
+				requestId: 'req-456',
+			});
+		});
+
+		it('should write multiple audit records in batch', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			auditor.audit('user.created', { userId: 1, email: 'user1@example.com' });
+			auditor.audit('user.created', { userId: 2, email: 'user2@example.com' });
+			auditor.audit('user.updated', { userId: 1, changes: ['name'] });
+
+			await auditor.flush();
+
+			const records = await db<AuditLogTable>(AUDIT_TABLE)
+				.select('*')
+				.orderBy('timestamp', 'asc');
+
+			expect(records).toHaveLength(3);
+			expect(records.map((r) => r.type).sort()).toEqual([
+				'user.created',
+				'user.created',
+				'user.updated',
+			]);
+		});
+
+		it('should do nothing for empty records', async () => {
+			await storage.write([]);
+
+			expect(await storage.count({})).toBe(0);
+		});
+
+		it('should persist old and new values', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			auditor.audit(
+				'user.updated',
+				{ userId: 1, changes: ['name'] },
+				{
+					operation: 'UPDATE',
+					oldValues: { name: 'Old Name' },
+					newValues: { name: 'New Name' },
+				},
+			);
+
+			await auditor.flush();
+
+			const [record] = await storage.query({});
+			expect(record.operation).toBe('UPDATE');
+			expect(record.oldValues).toEqual({ name: 'Old Name' });
+			expect(record.newValues).toEqual({ name: 'New Name' });
+		});
+
+		it('should round-trip complex entity IDs', async () => {
+			const records: AuditRecord[] = [
+				{
+					id: 'audit-complex-1',
+					type: 'relation.created',
+					operation: 'INSERT',
+					entityId: { userId: 'u1', roleId: 'r1' },
+					timestamp: new Date(),
+				},
+			];
+
+			await storage.write(records);
+
+			const [stored] = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+			expect(stored.entityId).toBe(
+				JSON.stringify({ userId: 'u1', roleId: 'r1' }),
+			);
+
+			const [queried] = await storage.query({});
+			expect(queried.entityId).toEqual({ userId: 'u1', roleId: 'r1' });
+		});
+
+		it('should store extra actor properties', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: {
+					id: 'user-1',
+					type: 'user',
+					email: 'user@example.com',
+					role: 'admin',
+				},
+				storage,
+			});
+
+			auditor.audit('user.created', { userId: 1, email: 'user@example.com' });
+			await auditor.flush();
+
+			const [stored] = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+			expect(stored.actorId).toBe('user-1');
+			expect(stored.actorType).toBe('user');
+			expect(stored.actorData).toEqual({
+				email: 'user@example.com',
+				role: 'admin',
+			});
+
+			const [queried] = await storage.query({});
+			expect(queried.actor).toEqual({
+				id: 'user-1',
+				type: 'user',
+				email: 'user@example.com',
+				role: 'admin',
+			});
+		});
+
+		it('should use the provided record ID', async () => {
+			await storage.write([
+				{
+					id: 'my-custom-id',
+					type: 'user.created',
+					operation: 'CUSTOM',
+					timestamp: new Date(),
+				},
+			]);
+
+			const [stored] = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+			expect(stored.id).toBe('my-custom-id');
+		});
+
+		it('should generate an ID when the record has none', async () => {
+			await storage.write([
+				{
+					id: '', // Empty ID
+					type: 'user.created',
+					operation: 'CUSTOM',
+					timestamp: new Date(),
+				},
+			]);
+
+			const [stored] = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+			expect(stored.id).toBeTruthy();
+			expect(stored.id.length).toBeGreaterThan(0);
+		});
+
+		it('should write audit records within transaction', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-123', type: 'user' },
+				storage,
+			});
+
+			await db.transaction(async (trx) => {
+				// Insert user
+				const [user] = await trx(USERS_TABLE)
+					.insert({ name: 'Test User', email: 'test@example.com' })
+					.returning('*');
+
+				// Audit the creation
+				auditor.audit(
+					'user.created',
+					{ userId: user.id, email: user.email },
+					{ entityId: String(user.id), table: 'users', operation: 'INSERT' },
+				);
+
+				// Flush within transaction
+				await auditor.flush(trx);
+			});
+
+			// Verify both user and audit record exist
+			const users = await db(USERS_TABLE).select('*');
+			const audits = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+
+			expect(users).toHaveLength(1);
+			expect(audits).toHaveLength(1);
+			expect(audits[0].entityId).toBe(String(users[0].id));
+			expect(audits[0].table).toBe('users');
+			expect(audits[0].operation).toBe('INSERT');
+		});
+
+		it('should rollback audit records when transaction fails', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-123', type: 'user' },
+				storage,
+			});
+
+			const transactionPromise = db.transaction(async (trx) => {
+				// Insert user
+				const [user] = await trx(USERS_TABLE)
+					.insert({ name: 'Rollback User', email: 'rollback@example.com' })
+					.returning('*');
+
+				// Audit the creation
+				auditor.audit('user.created', { userId: user.id, email: user.email });
+
+				// Flush within transaction
+				await auditor.flush(trx);
+
+				// Throw error to rollback
+				throw new Error('Transaction should rollback');
+			});
+
+			await expect(transactionPromise).rejects.toThrow(
+				'Transaction should rollback',
+			);
+
+			// Verify both user and audit record were rolled back
+			const users = await db(USERS_TABLE).select('*');
+			const audits = await db(AUDIT_TABLE).select('*');
+
+			expect(users).toHaveLength(0);
+			expect(audits).toHaveLength(0);
+		});
+	});
+
+	describe('autoId', () => {
+		it('should let the database generate IDs when autoId is true', async () => {
+			const autoIdStorage = new KnexAuditStorage({
+				db,
+				tableName: AUTO_ID_TABLE,
+				autoId: true,
+			});
+
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-1', type: 'user' },
+				storage: autoIdStorage,
+			});
+
+			auditor.audit('user.created', { userId: 1, email: 'auto@example.com' });
+			await auditor.flush();
+
+			const records = await db<AuditLogTable>(AUTO_ID_TABLE).select('*');
+			expect(records).toHaveLength(1);
+			expect(records[0].id).toMatch(/^[0-9a-f-]{36}$/);
+		});
+
+		it('should ignore a supplied ID when autoId is true', async () => {
+			const autoIdStorage = new KnexAuditStorage({
+				db,
+				tableName: AUTO_ID_TABLE,
+				autoId: true,
+			});
+
+			await autoIdStorage.write([
+				{
+					id: 'explicit-id', // Not a UUID - would fail if it reached the insert
+					type: 'user.created',
+					operation: 'CUSTOM',
+					timestamp: new Date(),
+				},
+			]);
+
+			const records = await db<AuditLogTable>(AUTO_ID_TABLE).select('*');
+			expect(records).toHaveLength(1);
+			expect(records[0].id).not.toBe('explicit-id');
+			expect(records[0].id).toMatch(/^[0-9a-f-]{36}$/);
+		});
+	});
+
+	describe('getDatabase', () => {
+		it('should return the knex instance', () => {
+			expect(storage.getDatabase()).toBe(db);
+		});
+	});
+
+	describe('withAuditableTransaction', () => {
+		it('should commit user and audits together', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			const created = await withAuditableTransaction(
+				db,
+				auditor,
+				async (trx) => {
+					const [user] = await trx(USERS_TABLE)
+						.insert({ name: 'Atomic User', email: 'atomic@example.com' })
+						.returning('*');
+
+					auditor.audit(
+						'user.created',
+						{ userId: user.id, email: user.email },
+						{ entityId: String(user.id), table: 'users', operation: 'INSERT' },
+					);
+
+					return user;
+				},
+			);
+
+			const audits = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+
+			expect(created.email).toBe('atomic@example.com');
+			expect(audits).toHaveLength(1);
+			expect(audits[0].entityId).toBe(String(created.id));
+		});
+
+		it('should roll back audits when the callback throws', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			await expect(
+				withAuditableTransaction(db, auditor, async (trx) => {
+					await trx(USERS_TABLE).insert({
+						name: 'Doomed User',
+						email: 'doomed@example.com',
+					});
+
+					auditor.audit('user.created', {
+						userId: 1,
+						email: 'doomed@example.com',
+					});
+
+					throw new Error('rollback please');
+				}),
+			).rejects.toThrow('rollback please');
+
+			const users = await db(USERS_TABLE).select('*');
+			const audits = await db(AUDIT_TABLE).select('*');
+
+			expect(users).toHaveLength(0);
+			expect(audits).toHaveLength(0);
+		});
+
+		it('should honour the requested isolation level', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			const level = await withAuditableTransaction(
+				db,
+				auditor,
+				async (trx) => {
+					const { rows } = await trx.raw('SHOW transaction_isolation');
+
+					auditor.audit('user.created', {
+						userId: 1,
+						email: 'isolated@example.com',
+					});
+
+					return rows[0].transaction_isolation as string;
+				},
+				{ isolationLevel: 'serializable' },
+			);
+
+			expect(level).toBe('serializable');
+			expect(await storage.count({})).toBe(1);
+		});
+
+		it('should reuse an existing transaction rather than opening a savepoint', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			// The outer transaction rolls back; if the inner call had opened a
+			// savepoint that committed independently, the audit would survive.
+			await expect(
+				db.transaction(async (outer) => {
+					await withAuditableTransaction(outer, auditor, async (trx) => {
+						await trx(USERS_TABLE).insert({
+							name: 'Nested User',
+							email: 'nested@example.com',
+						});
+
+						auditor.audit('user.created', {
+							userId: 1,
+							email: 'nested@example.com',
+						});
+					});
+
+					throw new Error('outer rollback');
+				}),
+			).rejects.toThrow('outer rollback');
+
+			const audits = await db(AUDIT_TABLE).select('*');
+			expect(audits).toHaveLength(0);
+		});
+	});
+
+	describe('withTransaction', () => {
+		it('should flush audits inside the transaction', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			const result = await storage.withTransaction(auditor, async () => {
+				auditor.audit('user.created', {
+					userId: 7,
+					email: 'wrapped@example.com',
+				});
+				return 'ok';
+			});
+
+			expect(result).toBe('ok');
+
+			const audits = await db<AuditLogTable>(AUDIT_TABLE).select('*');
+			expect(audits).toHaveLength(1);
+			expect(audits[0].type).toBe('user.created');
+		});
+
+		it('should not write audits when the callback throws', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			await expect(
+				storage.withTransaction(auditor, async () => {
+					auditor.audit('user.created', {
+						userId: 8,
+						email: 'never@example.com',
+					});
+					throw new Error('nope');
+				}),
+			).rejects.toThrow('nope');
+
+			expect(await storage.count({})).toBe(0);
+		});
+
+		it('should reuse a transaction passed in by the caller', async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+			});
+
+			await expect(
+				db.transaction(async (outer) => {
+					await storage.withTransaction(
+						auditor,
+						async () => {
+							auditor.audit('user.created', {
+								userId: 9,
+								email: 'reused@example.com',
+							});
+						},
+						outer,
+					);
+
+					throw new Error('outer rollback');
+				}),
+			).rejects.toThrow('outer rollback');
+
+			expect(await storage.count({})).toBe(0);
+		});
+	});
+
+	describe('query', () => {
+		beforeEach(async () => {
+			// Insert test audit records
+			const auditor1 = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-1', type: 'user' },
+				storage,
+				metadata: { endpoint: '/users' },
+			});
+
+			const auditor2 = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'admin-1', type: 'admin' },
+				storage,
+				metadata: { endpoint: '/admin/users' },
+			});
+
+			auditor1.audit(
+				'user.created',
+				{ userId: 1, email: 'user1@example.com' },
+				{ entityId: '1', table: 'users' },
+			);
+			auditor1.audit(
+				'user.updated',
+				{ userId: 1, changes: ['name'] },
+				{ entityId: '1', table: 'users' },
+			);
+			auditor2.audit(
+				'user.deleted',
+				{ userId: 2 },
+				{ entityId: '2', table: 'users' },
+			);
+
+			await auditor1.flush();
+			await auditor2.flush();
+		});
+
+		it('should query all records', async () => {
+			const records = await storage.query({});
+
+			expect(records).toHaveLength(3);
+		});
+
+		it('should filter by type', async () => {
+			const records = await storage.query({ type: 'user.created' });
+
+			expect(records).toHaveLength(1);
+			expect(records[0].type).toBe('user.created');
+		});
+
+		it('should filter by multiple types', async () => {
+			const records = await storage.query({
+				type: ['user.created', 'user.updated'],
+			});
+
+			expect(records).toHaveLength(2);
+		});
+
+		it('should filter by actorId', async () => {
+			const records = await storage.query({ actorId: 'admin-1' });
+
+			expect(records).toHaveLength(1);
+			expect(records[0].type).toBe('user.deleted');
+		});
+
+		it('should filter by entityId', async () => {
+			const records = await storage.query({ entityId: '1' });
+
+			expect(records).toHaveLength(2);
+		});
+
+		it('should filter by table', async () => {
+			const records = await storage.query({ table: 'users' });
+
+			expect(records).toHaveLength(3);
+		});
+
+		it('should filter by date range', async () => {
+			const past = new Date(Date.now() - 60_000);
+			const future = new Date(Date.now() + 60_000);
+
+			expect(await storage.query({ from: past, to: future })).toHaveLength(3);
+			expect(await storage.query({ from: future })).toHaveLength(0);
+			expect(await storage.query({ to: past })).toHaveLength(0);
+		});
+
+		it('should round-trip payload, actor and metadata', async () => {
+			const records = await storage.query({ type: 'user.created' });
+
+			expect(records[0].payload).toEqual({
+				userId: 1,
+				email: 'user1@example.com',
+			});
+			expect(records[0].actor).toEqual({ id: 'user-1', type: 'user' });
+			expect(records[0].metadata).toEqual({ endpoint: '/users' });
+		});
+
+		it('should apply pagination', async () => {
+			const page1 = await storage.query({ limit: 2, offset: 0 });
+			const page2 = await storage.query({ limit: 2, offset: 2 });
+
+			expect(page1).toHaveLength(2);
+			expect(page2).toHaveLength(1);
+		});
+
+		it('should order by timestamp descending by default', async () => {
+			const records = await storage.query({});
+
+			// Records should be in descending order (newest first)
+			for (let i = 1; i < records.length; i++) {
+				expect(records[i - 1].timestamp.getTime()).toBeGreaterThanOrEqual(
+					records[i].timestamp.getTime(),
+				);
+			}
+		});
+
+		it('should order by type ascending', async () => {
+			const records = await storage.query({
+				orderBy: 'type',
+				orderDirection: 'asc',
+			});
+
+			const types = records.map((r) => r.type);
+			expect(types).toEqual([...types].sort());
+		});
+	});
+
+	describe('count', () => {
+		beforeEach(async () => {
+			const auditor = new DefaultAuditor<TestAuditAction>({
+				actor: { id: 'user-1', type: 'user' },
+				storage,
+			});
+
+			auditor.audit('user.created', { userId: 1, email: 'user1@example.com' });
+			auditor.audit('user.created', { userId: 2, email: 'user2@example.com' });
+			auditor.audit('user.updated', { userId: 1, changes: ['name'] });
+
+			await auditor.flush();
+		});
+
+		it('should count all records', async () => {
+			const count = await storage.count({});
+
+			expect(count).toBe(3);
+		});
+
+		it('should count with type filter', async () => {
+			const count = await storage.count({ type: 'user.created' });
+
+			expect(count).toBe(2);
+		});
+
+		it('should count with multiple type filter', async () => {
+			const count = await storage.count({
+				type: ['user.created', 'user.updated'],
+			});
+
+			expect(count).toBe(3);
+		});
+
+		it('should count with actorId filter', async () => {
+			const count = await storage.count({ actorId: 'user-1' });
+
+			expect(count).toBe(3);
+		});
+	});
+});

--- a/packages/audit/src/knex.ts
+++ b/packages/audit/src/knex.ts
@@ -1,9 +1,4 @@
-import type {
-	ControlledTransaction,
-	IsolationLevel,
-	Kysely,
-	Transaction,
-} from 'kysely';
+import type { Knex } from 'knex';
 import { nanoid } from 'nanoid';
 import type {
 	AuditQueryOptions,
@@ -15,13 +10,26 @@ import type { AuditRecord } from './types';
 export type { TransactionAwareAuditor };
 
 export interface TransactionSettings {
-	isolationLevel?: IsolationLevel;
+	isolationLevel?: Knex.IsolationLevels;
 }
 
-export type DatabaseConnection<T> =
-	| ControlledTransaction<T>
-	| Kysely<T>
-	| Transaction<T>;
+export type DatabaseConnection = Knex | Knex.Transaction;
+
+/**
+ * Type guard for an active Knex transaction.
+ *
+ * Knex marks transaction instances with `isTransaction`, and a completed
+ * transaction can no longer be used, so a settled transaction is treated as a
+ * plain connection.
+ */
+function isActiveTransaction(
+	connection: DatabaseConnection,
+): connection is Knex.Transaction {
+	return (
+		connection.isTransaction === true &&
+		!(connection as Knex.Transaction).isCompleted()
+	);
+}
 
 /**
  * Execute a callback within a database transaction with automatic audit handling.
@@ -37,7 +45,7 @@ export type DatabaseConnection<T> =
  * If you need all audits to be atomic with your database operations, use manual
  * audits via `auditor.audit()` inside this wrapper.
  *
- * @param db - Database connection (Kysely, Transaction, or ControlledTransaction)
+ * @param db - Database connection (Knex instance or Transaction)
  * @param auditor - Auditor instance that will receive the transaction
  * @param cb - Callback to execute within the transaction
  * @param settings - Optional transaction settings (isolation level)
@@ -45,17 +53,13 @@ export type DatabaseConnection<T> =
  *
  * @example
  * ```typescript
- * import { withAuditableTransaction } from '@geekmidas/audit/kysely';
+ * import { withAuditableTransaction } from '@geekmidas/audit/knex';
  *
  * const result = await withAuditableTransaction(
  *   services.database,
  *   auditor,
  *   async (trx) => {
- *     const user = await trx
- *       .insertInto('users')
- *       .values(data)
- *       .returningAll()
- *       .executeTakeFirstOrThrow();
+ *     const [user] = await trx('users').insert(data).returning('*');
  *
  *     // Manual audits are atomic with the transaction
  *     auditor.audit('user.created', { userId: user.id, email: user.email });
@@ -66,13 +70,13 @@ export type DatabaseConnection<T> =
  * // Audits are automatically flushed inside the transaction before commit
  * ```
  */
-export async function withAuditableTransaction<DB, T>(
-	db: DatabaseConnection<DB>,
-	auditor: TransactionAwareAuditor<Transaction<DB>>,
-	cb: (trx: Transaction<DB>) => Promise<T>,
+export async function withAuditableTransaction<T>(
+	db: DatabaseConnection,
+	auditor: TransactionAwareAuditor<Knex.Transaction>,
+	cb: (trx: Knex.Transaction) => Promise<T>,
 	settings?: TransactionSettings,
 ): Promise<T> {
-	const execute = async (trx: Transaction<DB>): Promise<T> => {
+	const execute = async (trx: Knex.Transaction): Promise<T> => {
 		// Register transaction with auditor
 		auditor.setTransaction(trx);
 
@@ -86,31 +90,36 @@ export async function withAuditableTransaction<DB, T>(
 		return result;
 	};
 
-	// If already in a transaction, just run with it
-	if (db.isTransaction) {
-		return execute(db as Transaction<DB>);
+	// If already in a transaction, just run with it.
+	// Knex would otherwise open a savepoint, which commits independently.
+	if (isActiveTransaction(db)) {
+		return execute(db);
 	}
 
-	const builder = db.transaction();
-
-	if (settings?.isolationLevel) {
-		return builder.setIsolationLevel(settings.isolationLevel).execute(execute);
-	}
-
-	return builder.execute(execute);
+	return db.transaction(execute, settings);
 }
 
 /**
- * Database table interface for audit records.
- * Use this to define your audit_logs table in your Kysely database schema.
+ * Shape of a row in the audit log table.
+ * Use this to describe your audit table when declaring Knex table types.
  *
- * Column names use snake_case to match standard PostgreSQL conventions.
+ * Property names are camelCase to match the Kysely storage. Pair this with
+ * `knexSnakeCaseMappers()` if your database columns are snake_case.
  *
  * @example
  * ```typescript
- * interface Database {
- *   audit_logs: AuditLogTable;
- *   // ... other tables
+ * import { knexSnakeCaseMappers } from 'objection';
+ *
+ * const db = knex({
+ *   client: 'pg',
+ *   connection: process.env.DATABASE_URL,
+ *   ...knexSnakeCaseMappers(),
+ * });
+ *
+ * declare module 'knex/types/tables' {
+ *   interface Tables {
+ *     audit_logs: AuditLogTable;
+ *   }
  * }
  * ```
  */
@@ -132,30 +141,20 @@ export interface AuditLogTable {
 
 /**
  * Insertable version of AuditLogTable where id is optional.
- * Use this when your database auto-generates IDs or when using autoId option.
- *
- * @example
- * ```typescript
- * interface Database {
- *   audit_logs: AuditLogTable;
- * }
- *
- * // For insertions where id is auto-generated
- * type NewAuditLog = InsertableAuditLogTable;
- * ```
+ * Use this when your database auto-generates IDs or when using the autoId option.
  */
 export type InsertableAuditLogTable = Omit<AuditLogTable, 'id'> & {
 	id?: string;
 };
 
 /**
- * Configuration for KyselyAuditStorage.
+ * Configuration for KnexAuditStorage.
  */
-export interface KyselyAuditStorageConfig<DB> {
-	/** Kysely database instance */
-	db: Kysely<DB>;
-	/** Table name for audit logs (must be a key in DB that extends AuditLogTable) */
-	tableName: keyof DB & string;
+export interface KnexAuditStorageConfig {
+	/** Knex database instance */
+	db: Knex;
+	/** Table name for audit logs */
+	tableName: string;
 	/**
 	 * Service name of the database service.
 	 * When set, endpoint adaptors will automatically use the audit transaction as `db`
@@ -172,19 +171,13 @@ export interface KyselyAuditStorageConfig<DB> {
 }
 
 /**
- * Kysely-based audit storage implementation.
- * Stores audit records in a database table using Kysely.
- *
- * @template DB - Your Kysely database schema
+ * Knex-based audit storage implementation.
+ * Stores audit records in a database table using Knex.
  *
  * @example
  * ```typescript
- * interface Database {
- *   audit_logs: AuditLogTable;
- * }
- *
- * const storage = new KyselyAuditStorage({
- *   db: kyselyDb,
+ * const storage = new KnexAuditStorage({
+ *   db: knexDb,
  *   tableName: 'audit_logs',
  * });
  *
@@ -194,13 +187,13 @@ export interface KyselyAuditStorageConfig<DB> {
  * });
  * ```
  */
-export class KyselyAuditStorage<DB> implements AuditStorage {
-	private readonly db: Kysely<DB>;
-	private readonly tableName: keyof DB & string;
+export class KnexAuditStorage implements AuditStorage {
+	private readonly db: Knex;
+	private readonly tableName: string;
 	private readonly autoId: boolean;
 	readonly databaseServiceName?: string;
 
-	constructor(config: KyselyAuditStorageConfig<DB>) {
+	constructor(config: KnexAuditStorageConfig) {
 		this.db = config.db;
 		this.tableName = config.tableName;
 		this.databaseServiceName = config.databaseServiceName;
@@ -212,14 +205,14 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 			return;
 		}
 
-		const db = (trx as Transaction<DB>) ?? this.db;
+		const db = (trx as Knex.Transaction) ?? this.db;
 		const rows = records.map((record) => this.toRow(record));
 
-		await (db as any).insertInto(this.tableName).values(rows).execute();
+		await db(this.tableName).insert(rows);
 	}
 
 	async query(options: AuditQueryOptions): Promise<AuditRecord[]> {
-		let query = (this.db as any).selectFrom(this.tableName).selectAll();
+		let query = this.db(this.tableName).select('*');
 
 		query = this.applyFilters(query, options);
 
@@ -239,57 +232,54 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 			query = query.offset(options.offset);
 		}
 
-		const rows = await query.execute();
+		const rows = await query;
 		return rows.map((row: AuditLogTable) => this.fromRow(row));
 	}
 
 	async count(
 		options: Omit<AuditQueryOptions, 'limit' | 'offset'>,
 	): Promise<number> {
-		let query = (this.db as any)
-			.selectFrom(this.tableName)
-			.select((eb: any) => eb.fn.count('id').as('count'));
+		let query = this.db(this.tableName).count({ count: 'id' });
 
 		query = this.applyFilters(query, options);
 
-		const result = await query.executeTakeFirst();
+		const result = await query.first();
 		return Number(result?.count ?? 0);
 	}
 
 	/**
-	 * Get the Kysely database instance for transactional operations.
+	 * Get the Knex database instance for transactional operations.
 	 * Used by endpoint adaptors to automatically wrap handlers in transactions.
 	 */
-	getDatabase(): Kysely<DB> {
+	getDatabase(): Knex {
 		return this.db;
 	}
 
 	/**
-	 * Execute a callback within a Kysely transaction with automatic audit handling.
+	 * Execute a callback within a Knex transaction with automatic audit handling.
 	 * The auditor is registered with the transaction and audits are flushed
 	 * before the transaction commits.
 	 *
 	 * If the provided db connection is already a transaction, it will be reused
-	 * instead of creating a nested transaction.
+	 * instead of opening a savepoint.
 	 */
 	async withTransaction<T>(
-		auditor: TransactionAwareAuditor<Transaction<DB>>,
+		auditor: TransactionAwareAuditor<Knex.Transaction>,
 		callback: () => Promise<T>,
-		db?: DatabaseConnection<DB>,
+		db?: DatabaseConnection,
 	): Promise<T> {
 		const connection = db ?? this.db;
 
 		// If already in a transaction, reuse it
-		if (connection.isTransaction) {
-			const trx = connection as Transaction<DB>;
-			auditor.setTransaction(trx);
+		if (isActiveTransaction(connection)) {
+			auditor.setTransaction(connection);
 			const result = await callback();
-			await auditor.flush(trx);
+			await auditor.flush(connection);
 			return result;
 		}
 
 		// Create new transaction
-		return connection.transaction().execute(async (trx) => {
+		return connection.transaction(async (trx) => {
 			auditor.setTransaction(trx);
 			const result = await callback();
 			await auditor.flush(trx);
@@ -301,9 +291,9 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 		// Type filter
 		if (options.type !== undefined) {
 			if (Array.isArray(options.type)) {
-				query = query.where('type', 'in', options.type);
+				query = query.whereIn('type', options.type);
 			} else {
-				query = query.where('type', '=', options.type);
+				query = query.where('type', options.type);
 			}
 		}
 
@@ -313,17 +303,17 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 				typeof options.entityId === 'string'
 					? options.entityId
 					: JSON.stringify(options.entityId);
-			query = query.where('entityId', '=', entityId);
+			query = query.where('entityId', entityId);
 		}
 
 		// Table filter
 		if (options.table !== undefined) {
-			query = query.where('table', '=', options.table);
+			query = query.where('table', options.table);
 		}
 
 		// Actor ID filter
 		if (options.actorId !== undefined) {
-			query = query.where('actorId', '=', options.actorId);
+			query = query.where('actorId', options.actorId);
 		}
 
 		// Date range filters
@@ -353,15 +343,17 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 					: typeof record.entityId === 'string'
 						? record.entityId
 						: JSON.stringify(record.entityId),
-			oldValues: record.oldValues ?? null,
-			newValues: record.newValues ?? null,
-			payload: record.payload ?? null,
+			oldValues: this.toJsonColumn(record.oldValues),
+			newValues: this.toJsonColumn(record.newValues),
+			payload: this.toJsonColumn(record.payload),
 			timestamp: record.timestamp,
 			actorId: record.actor?.id ?? null,
 			actorType: record.actor?.type ?? null,
 			actorData:
-				record.actor !== undefined ? this.getActorData(record.actor) : null,
-			metadata: record.metadata ?? null,
+				record.actor !== undefined
+					? this.toJsonColumn(this.getActorData(record.actor))
+					: null,
+			metadata: this.toJsonColumn(record.metadata),
 		} as AuditLogTable;
 	}
 
@@ -388,6 +380,20 @@ export class KyselyAuditStorage<DB> implements AuditStorage {
 			actor,
 			metadata: row.metadata ? this.parseJson(row.metadata) : undefined,
 		};
+	}
+
+	/**
+	 * Serialize a JSON value for insertion.
+	 *
+	 * Unlike Kysely, Knex has no per-column type information to tell a json/jsonb
+	 * column from an object it should bind as a composite value, so plain objects
+	 * are stringified before they reach the driver.
+	 */
+	private toJsonColumn(value: unknown): string | null {
+		if (value === undefined || value === null) {
+			return null;
+		}
+		return JSON.stringify(value);
 	}
 
 	/**

--- a/packages/audit/src/storage.ts
+++ b/packages/audit/src/storage.ts
@@ -1,6 +1,34 @@
 import type { AuditableAction, AuditRecord } from './types';
 
 /**
+ * Minimal interface for transaction-aware audit flushing.
+ * Use this when you need to flush audits within a database transaction.
+ *
+ * @template TTransaction - Transaction type (e.g., Kysely `Transaction`, Knex `Transaction`)
+ *
+ * @example
+ * ```typescript
+ * import { withAuditableTransaction } from '@geekmidas/audit/kysely';
+ * import type { TransactionAwareAuditor } from '@geekmidas/audit/kysely';
+ *
+ * const result = await withAuditableTransaction(
+ *   db,
+ *   auditor as TransactionAwareAuditor<Transaction<DB>>,
+ *   async (trx) => {
+ *     // Your transactional operations
+ *     return result;
+ *   },
+ * );
+ * ```
+ */
+export interface TransactionAwareAuditor<TTransaction = unknown> {
+	/** Register the transaction with the auditor for use during flush */
+	setTransaction(trx: TTransaction): void;
+	/** Flush all pending audits, optionally within a transaction */
+	flush(trx?: TTransaction): Promise<void>;
+}
+
+/**
  * Options for querying audit records.
  */
 export interface AuditQueryOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@types/pg':
         specifier: ~8.15.6
         version: 8.15.6
+      knex:
+        specifier: ~3.1.0
+        version: 3.1.0(pg@8.16.3)
       kysely:
         specifier: ~0.29.4
         version: 0.29.4
@@ -7014,6 +7017,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -13434,14 +13438,14 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.1.13
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.13))(jose@6.1.2)(kysely@0.29.4)(nanostores@1.1.0)':
+  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.0.0
       better-call: 1.1.8(zod@4.3.6)
       jose: 6.1.2
-      kysely: 0.29.4
+      kysely: 0.28.8
       nanostores: 1.1.0
       zod: 4.3.6
 
@@ -13451,9 +13455,9 @@ snapshots:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
 
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0))':
+  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.13))(jose@6.1.2)(kysely@0.29.4)(nanostores@1.1.0))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.13))(jose@6.1.2)(kysely@0.29.4)(nanostores@1.1.0)
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
 
@@ -18683,8 +18687,8 @@ snapshots:
 
   better-auth@1.4.18(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.9.1)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.10.3(@types/node@24.9.1)(typescript@5.8.2))(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.2))(vue@3.5.18(typescript@5.8.2)):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.13))(jose@6.1.2)(kysely@0.29.4)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0))
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.2)(kysely@0.28.8)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.13))(jose@6.1.2)(kysely@0.29.4)(nanostores@1.1.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.0.1


### PR DESCRIPTION
Adds a `@geekmidas/audit/knex` entry point so Knex users get the same audit storage Kysely users already have.

## What's here

`KnexAuditStorage` mirrors `KyselyAuditStorage`:

- Same config: `db`, `tableName`, `databaseServiceName`, `autoId`
- Same `write()` / `query()` / `count()` — identical filters, pagination, ordering
- `getDatabase()`, `withTransaction()`, and a `withAuditableTransaction()` helper

`TransactionAwareAuditor` moved to `storage.ts` so both backends share one definition. It's still re-exported from `./kysely`, so existing imports keep working.

## Two places Knex genuinely differs

**JSON columns are stringified.** Kysely knows a column is `jsonb` and binds objects directly. Knex has no per-column type information, so `toJsonColumn()` serializes `payload` / `oldValues` / `newValues` / `actorData` / `metadata` before they reach the driver. Values round-trip identically — tests assert this both at the raw-row level and through `query()`.

**Nested transactions open savepoints.** Calling `.transaction()` on an existing Knex transaction creates a savepoint, which can release independently of the outer transaction. Both `withAuditableTransaction` and `withTransaction` detect an active transaction and reuse it. There's a test that rolls back an outer transaction and asserts the audit vanishes; it fails if that guard is removed.

## Endpoint integration needed no changes

`executeWithAuditTransaction` (`processAudits.ts:340`) only calls `storage.withTransaction(auditor, cb, db)`, and the Hono / API-Gateway adaptors only read `databaseServiceName` and `auditor.getTransaction()`. `KnexAuditStorage` provides all three, so endpoints wrap handler + audit flush in a single transaction with Knex exactly as with Kysely.

## Testing

Tested against a real Postgres database rather than mocks, following the repo's integration-over-unit philosophy — 35 tests covering writes, batching, JSON round-tripping, complex entity IDs, actor data, `autoId`, all query filters, pagination, ordering, counts, isolation levels, transaction commit/rollback, and transaction reuse.

`tsc` clean, Biome clean, `tsdown` emits `dist/knex.{mjs,cjs,d.mts,d.cts}`, full audit suite passes (136 tests).

## Notes for the reviewer

- **`knex` is an optional peer dependency**, so Kysely-only consumers are unaffected.
- **Column names are camelCase**, matching the Kysely storage. Documented pairing with `knexSnakeCaseMappers()` for snake_case schemas.
- **Lockfile churn:** adding `knex` makes pnpm reshuffle which `kysely` variant `@better-auth/core` resolves against (0.29.4 ↔ 0.28.8). That peer constraint was already unsatisfiable on `main` (`unmet peer kysely@^0.28.5: found 0.29.4` predates this branch). The diff is pnpm's own output from `pnpm install --lockfile-only`, not a hand edit — flagging it since it's unrelated to audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmXWm3WJmNz1qT3uRqeDp2
