### PR TITLE
chore: patch release across all packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": ["@geekmidas/docs"]
+	"ignore": ["@geekmidas/docs"],
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	}
 }

--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,29 @@
+---
+'@geekmidas/audit': patch
+'@geekmidas/auth': patch
+'@geekmidas/cache': patch
+'@geekmidas/cli': patch
+'@geekmidas/client': patch
+'@geekmidas/cloud': patch
+'@geekmidas/constructs': patch
+'@geekmidas/db': patch
+'@geekmidas/emailkit': patch
+'@geekmidas/envkit': patch
+'@geekmidas/errors': patch
+'@geekmidas/events': patch
+'@geekmidas/logger': patch
+'@geekmidas/manifest': patch
+'@geekmidas/rate-limit': patch
+'@geekmidas/schema': patch
+'@geekmidas/services': patch
+'@geekmidas/storage': patch
+'@geekmidas/studio': patch
+'@geekmidas/telescope': patch
+'@geekmidas/testkit': patch
+'@geekmidas/ui': patch
+---
+
+Patch release across all packages to realign published versions with the
+registry. The previous release only published the four packages that had
+version bumps; the remaining packages failed with "cannot publish over the
+previously published versions" because their versions were unchanged.


### PR DESCRIPTION
Fixes the failed publish on `main` ([run 31510785136](https://github.com/geekmidas/toolbox/actions/runs/31510785136/job/93843772607)).

## What happened

The release triggered by #10 published 4 packages and failed on 18:

```
success packages published successfully:
  @geekmidas/audit@2.2.0, @geekmidas/cli@2.0.1,
  @geekmidas/client@9.0.0, @geekmidas/constructs@7.0.0

error packages failed to publish:
  @geekmidas/auth@2.0.1, @geekmidas/cache@1.1.1, ... (18 total)
  npm error You cannot publish over the previously published versions
```

Only those four had version bumps. The other 18 were at versions already on the registry, so `changeset publish` attempted them and npm rejected each one — failing the job.

## The fix

A changeset patching all 22 publishable packages, so every package gets a version that isn't on npm yet and publish can complete.

## Why the config change

Marking everything `patch` isn't enough on its own. By default changesets **major**-bumps any package with a `peerDependency` on a released package, and `@geekmidas/constructs` peer-depends on ten workspace packages. The resolved plan was:

| Package | Without the flag | With the flag |
|---|---|---|
| `@geekmidas/constructs` | 7.0.0 → **8.0.0** | 7.0.0 → 7.0.1 |
| `@geekmidas/client` | 9.0.0 → **10.0.0** | 9.0.0 → 9.0.1 |
| 20 others | patch | patch |

`client` inherits it by peer-depending on `constructs`. Every workspace peer range is `workspace:^`, so a patch bump keeps them satisfied and no major is warranted — `onlyUpdatePeerDependentsWhenOutOfRange: true` makes changesets bump peer dependents only when the range actually breaks.

Verified resolved plan: **25 releases, all patch, zero major or minor.**

## Note on the underlying cause

`changeset publish` is supposed to query the registry and skip already-published packages, so it arguably shouldn't have attempted those 18 at all. The job log shows npm config warnings interleaved with output (`Unknown env config "_jsr-registry"`, `"verify-deps-before-run"`, `"npm-globalconfig"`), which could be contaminating the `npm info` responses changesets parses to decide what's unpublished — but I haven't confirmed that, and it's outside this PR.

This PR makes the next release succeed. It does not harden the workflow against a future release where only some packages are bumped, which would hit the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmXWm3WJmNz1qT3uRqeDp2
