### PR TITLE
The CLI and the docs describe the constructs model

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@
 
 **@geekmidas/toolbox** is a collection of TypeScript utilities and frameworks designed to accelerate web application development. Built with modern tooling and best practices, it provides type-safe, developer-friendly APIs for common tasks.
 
+> **Working on `main` (v10):** everything is a construct. A database, bucket,
+> cache, or credential is one declaration in application code, and the local
+> container, the deployed resource, the handler's environment, and its client
+> all derive from it. See
+> [Constructs Paradigm](./docs/design/constructs-paradigm.md).
+
 ### Key Features
 
+- 🧱 **Declared infrastructure**: `new KyselyDatabase<Database, 'Orders'>('Orders')` is the whole declaration — the container, the roles, the schema, and `ORDERS_URL` all come from it
+- 🔗 **One dependency edge**: `.dependsOn([uploads])` derives the handler's environment, its client, and exactly the cloud access it named
 - 🔒 **Type Safety**: Full TypeScript support with runtime validation
 - 📦 **Monorepo Structure**: Organized packages with clear separation of concerns
 - 🚀 **Modern Tooling**: pnpm, Turbo, tsdown, Biome, and Vitest
@@ -36,8 +44,10 @@
 
 ### [@geekmidas/constructs](./packages/constructs)
 
-A powerful framework for building type-safe HTTP endpoints, cloud functions, cron jobs, and event subscribers.
+A powerful framework for building type-safe HTTP endpoints, cloud functions, cron jobs, event subscribers — and the infrastructure they depend on.
 
+- Declared resources: `KyselyDatabase`, `ObjectStorage`, `FileServer`, `Cache`, `Credential`, `Email`, `Topic`, `Queue`, `RestApi`, `StaticSite`
+- `.dependsOn([…])` — the edge that derives environment, client, and cloud access
 - Type-safe endpoint definitions with automatic type inference
 - Schema validation using StandardSchema (Zod, Valibot, etc.)
 - AWS Lambda support with API Gateway integration
@@ -48,10 +58,16 @@ A powerful framework for building type-safe HTTP endpoints, cloud functions, cro
 - Cloud functions, cron jobs, and event subscriber support
 
 ```typescript
+import { KyselyDatabase } from '@geekmidas/constructs/database/kysely';
 import { e } from '@geekmidas/constructs/endpoints';
 import { z } from 'zod';
 
-const endpoint = e
+// One declaration: the Postgres container, its roles and schema, and ORDERS_URL.
+export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
+
+const router = e.database(database);
+
+const endpoint = router
   .get('/users/:id')
   .params(z.object({ id: z.string().uuid() }))
   .query(z.object({
@@ -59,8 +75,12 @@ const endpoint = e
     'filter.status': z.enum(['active', 'inactive']).optional()
   }))
   .output(UserSchema)
-  .handle(async ({ params, query }) => {
-    return getUserById(params.id, query);
+  .handle(async ({ params, query, db }) => {
+    return db
+      .selectFrom('users')
+      .where('id', '=', params.id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
   });
 ```
 
@@ -256,7 +276,9 @@ throw createError.badRequest('Invalid input', { field: 'email' });
 
 ### [@geekmidas/services](./packages/services)
 
-Service discovery and dependency injection system.
+Service discovery and dependency injection system — the escape hatch for
+anything no construct describes. Infrastructure is a construct; a third-party
+SDK or a client you assemble yourself is a `Service`.
 
 - Singleton service registry with lazy initialization
 - Type-safe service registration and retrieval
@@ -570,8 +592,9 @@ toolbox/
 │   ├── cli/          # Command-line tools
 │   ├── client/       # Type-safe API client with React Query
 │   ├── cloud/        # Cloud services (SST integration)
-│   ├── constructs/   # Endpoints, functions, cron jobs, subscribers
+│   ├── constructs/   # Endpoints, functions, crons, subscribers, and declared resources
 │   ├── db/           # Database utilities for Kysely
+│   ├── manifest/     # Declarations, naming, derivation — the build/run seam
 │   ├── emailkit/     # Email sending utilities
 │   ├── envkit/       # Environment configuration parser
 │   ├── errors/       # HTTP error classes and utilities
@@ -631,6 +654,10 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - [x] Declarative audit logging in constructs
 
 ### In Progress 🚧
+- [x] Constructs paradigm — thirteen declaration kinds, a construct for each one that needs it
+- [x] Reconcile — local containers, databases, roles, and buckets derived from declarations
+- [ ] AWS target: `rest-api` (twelve of thirteen kinds provision; nothing deployed end to end yet)
+- [ ] Fullstack workspace on the constructs path (its auth app declares no half yet)
 - [ ] Cloud services abstractions (@geekmidas/cloud)
 - [ ] Documentation site improvements
 - [ ] Comprehensive test coverage for all packages

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         text: 'Core Packages',
         items: [
           { text: '@geekmidas/constructs', link: '/packages/constructs' },
+          { text: '@geekmidas/manifest', link: '/packages/manifest' },
           { text: '@geekmidas/client', link: '/packages/client' },
           { text: '@geekmidas/cli', link: '/packages/cli' },
         ],

--- a/apps/docs/guide/cli-reference.md
+++ b/apps/docs/guide/cli-reference.md
@@ -23,15 +23,27 @@ Create a `gkm.config.ts` file in your project root:
 import { defineConfig } from '@geekmidas/cli/config';
 
 export default defineConfig({
+  // Constructs — one glob, every kind. What reconcile reads to derive this
+  // app's containers, databases, roles, and buckets.
+  constructs: 'src/constructs/**/*.ts',
+
   // Required
   routes: 'src/endpoints/**/*.ts',
   envParser: './src/config/env',
   logger: './src/config/logger',
 
-  // Optional construct patterns
+  // Function globs. A resource has no kind to be listed under, which is why
+  // `constructs` above is separate from these.
   functions: 'src/functions/**/*.ts',
   crons: 'src/crons/**/*.ts',
   subscribers: 'src/subscribers/**/*.ts',
+
+  // What no construct implies — a backend selection, not a resource list.
+  services: {
+    cache: true,      // or 'upstash' | 'elasticache' | 'db'
+    mail: true,       // or 'ses' | 'resend' | 'smtp'
+    events: 'pgboss', // or 'sns' | 'rabbitmq'
+  },
 
   // Development tools
   telescope: {
@@ -134,6 +146,22 @@ Fixed port mappings (e.g., `'8080:80'`) are intentionally skipped — only env v
 **Port persistence:**
 
 Resolved ports are saved to `.gkm/ports.json` so that external tools (like pgAdmin, database GUIs, etc.) keep working across restarts. The `.gkm/` directory is automatically gitignored.
+
+### `gkm setup`
+
+Reconcile only — derive the containers, databases, roles, schemas, and buckets
+the declared constructs name, and stop there.
+
+```bash
+gkm setup                      # reconcile the development stage
+gkm setup --stage staging      # another stage
+gkm setup --skip-docker        # secrets and validation only
+gkm setup --force              # regenerate secrets even if they exist
+```
+
+`gkm dev` and `gkm test` call the same function before they start anything, so
+this is only needed when you want the infrastructure without the server — after
+a clone, or after adding a construct.
 
 ### `gkm build`
 

--- a/apps/docs/guide/deployment.md
+++ b/apps/docs/guide/deployment.md
@@ -5,11 +5,39 @@ This guide covers deploying @geekmidas workspace applications to various targets
 ## Overview
 
 The CLI provides a complete deployment pipeline for monorepo workspaces:
-- **Environment Sniffing** - Automatic detection of required environment variables
+- **The manifest** - what `gkm build` writes, and the seam every target reads
+- **Environment Sniffing** - detection of required environment variables for the code a construct cannot describe
 - **State Management** - Track deployments across local and remote storage
 - **DNS Automation** - Automatic DNS configuration with multiple providers
 - **Secrets Management** - Encrypted secrets injection during builds
 - **Multi-App Orchestration** - Coordinated deployment of workspace apps
+
+## The manifest is the seam
+
+`gkm build` writes a **manifest**: every construct an app declared, and every
+edge between them. Deploying is a target reading that manifest.
+
+```
+src/constructs/*.ts        the declarations
+        │
+        ▼  gkm build
+   the manifest            what exists, and what depends on what
+        │
+        ├──▶ --target=server / Dokploy   containers and URLs
+        └──▶ --target=aws                RDS, S3, SNS, SQS, Lambda, …
+```
+
+The manifest records **what is depended on**, never what that implies. Turning
+an edge into an IAM policy, a security group, or a link is the target adapter's
+business — which is why the same declaration deploys to a container host and to
+AWS without naming either.
+
+::: warning What is not built yet
+The AWS target provisions twelve of the thirteen declaration kinds; `rest-api`
+is outstanding. Its decisions are unit-tested as pure functions, but **a stack
+has never come up end to end**. The server/Dokploy path below is the one in use
+today.
+:::
 
 ## Quick Start
 
@@ -25,6 +53,7 @@ export default defineWorkspace({
       path: 'apps/api',
       type: 'backend',
       port: 3000,
+      constructs: './src/constructs/**/*.ts',
       routes: './src/endpoints/**/*.ts',
       envParser: './src/config/env',
       logger: './src/config/logger',
@@ -46,8 +75,8 @@ export default defineWorkspace({
     },
   },
 
+  // Backend selection. The Postgres itself comes from the declared database.
   services: {
-    db: true,
     cache: true,
   },
 
@@ -158,15 +187,24 @@ The CLI handles environment variables differently in development and production.
 
 In development, environment variables come from multiple sources:
 
-**1. Docker Compose Services**
+**1. Declared constructs**
 
-When services are configured, connection URLs are auto-generated:
+A declaration is what publishes a URL, under the key it owns:
+
+```typescript
+new KyselyDatabase<Database, 'Orders'>('Orders');  // → ORDERS_URL, ORDERS_OWNER_URL
+new ObjectStorage('Uploads');                      // → UPLOADS_URL
+new Cache('Sessions');                             // → SESSIONS_URL
+new Email('Mail');                                 // → MAIL_URL, MAIL_FROM
+```
+
+Backends that no construct implies are still config, and still generate their
+own URLs:
 
 ```typescript
 services: {
-  db: true,    // → DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-  cache: true, // → REDIS_URL=redis://localhost:6379
-  mail: true,  // → SMTP_HOST=localhost, SMTP_PORT=1025
+  cache: true,      // → a Redis (or the Upstash proxy, per backend)
+  events: 'pgboss', // → EVENT_PUBLISHER_CONNECTION_STRING, EVENT_SUBSCRIBER_CONNECTION_STRING
 }
 ```
 
@@ -219,7 +257,17 @@ gkm secrets:set SENDGRID_API_KEY SG.xxx --stage production
 
 ## Environment Sniffing
 
-The CLI automatically detects required environment variables by analyzing your code.
+Sniffing is what covers the code a construct cannot describe.
+
+A declared construct needs none of it: the build knows `UPLOADS_URL` exists
+because `ObjectStorage` declared it, and knows which handler needs it because
+the handler named that construct in `.dependsOn()`. Sniffing is the fallback for
+hand-written services and entry files, where the only way to learn which keys
+are touched is to run the code and watch.
+
+That difference is worth knowing when a variable goes missing: a construct's key
+is a fact in the manifest, while a sniffed key is an observation, and an
+observation can be wrong if the service throws before it reads.
 
 ### Detection Strategy (Priority Order)
 
@@ -253,8 +301,8 @@ These variables are automatically resolved without manual configuration:
 | `PORT` | App config or default |
 | `NODE_ENV` | Always `'production'` |
 | `STAGE` | Deployment stage name |
-| `DATABASE_URL` | Generated per-app credentials |
-| `REDIS_URL` | Provisioned Redis service |
+| `DATABASE_URL` | Generated per-app credentials (the hand-written path — a declared database publishes `<NAME>_URL` instead) |
+| `REDIS_URL` | Provisioned Redis service (a declared `Cache` publishes `<NAME>_URL` instead) |
 | `BETTER_AUTH_URL` | Derived from app hostname |
 | `BETTER_AUTH_SECRET` | Generated and persisted |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | All frontend URLs |

--- a/apps/docs/guide/dev-server.md
+++ b/apps/docs/guide/dev-server.md
@@ -6,6 +6,36 @@ A complete guide to `gkm dev` — what it does, how it orchestrates a fullstack 
 
 `gkm dev` is the primary development command. It detects whether you're in a single-app project or a multi-app workspace and adjusts its behavior accordingly. For fullstack workspaces, it orchestrates Docker services, resolves ports, decrypts and injects secrets, starts all apps via Turbo, and watches for changes.
 
+## Two paths
+
+`gkm dev` takes one of two paths, and which one depends on a single question:
+**does any app configure a `constructs` glob?**
+
+| | Declared | Hand-written |
+|---|---|---|
+| Trigger | at least one app sets `constructs:` | no app does |
+| Where containers come from | the manifest — a declared `KyselyDatabase` is why a Postgres exists | a `docker-compose.yml` you wrote |
+| Where URLs come from | derived and injected (`ORDERS_URL`, `UPLOADS_URL`) | secrets, rewritten with resolved ports |
+| Compose file | generated at `.gkm/docker-compose.yml` | yours, at the project root |
+
+Steps 5 through 8 below describe the **hand-written** path. On the declared
+path, all four collapse into one reconcile pass:
+
+```
+🐳 Services: postgres, minio
+   postgres: postgresql://…@localhost:5432/orders
+   minio: http://localhost:9000
+```
+
+Reconcile computes the desired state, compares it against what is running, and
+applies the difference — allocating ports, writing compose, starting containers,
+and creating the databases, roles, schemas, and buckets the declarations name.
+It is safe on every start: the converged case costs one hash and one health
+check, and its blast radius is this project's containers and `.gkm/`.
+
+See [Getting Started](/guide/getting-started) for the declaration side, and
+[@geekmidas/cli](/packages/cli#reconcile) for what reconcile does in detail.
+
 ## Quick Reference
 
 ```bash
@@ -48,6 +78,12 @@ For each backend app that has generated an OpenAPI spec (`.gkm/openapi.ts`), the
 
 ### 5. Resolve Docker Service Ports
 
+::: info Hand-written path
+Steps 5–8 apply when no app declares constructs. Where one does, reconcile
+replaces all four — there is no hand-written compose file left to read ports out
+of.
+:::
+
 ```
 🔌 Resolving service ports...
    ✅ postgres:5432: using default port 5432
@@ -76,6 +112,10 @@ Runs `docker compose up -d` with the resolved port environment variables injecte
 | `services.db: true` | `postgres` |
 | `services.cache: true` | `redis` |
 | `services.mail: true` | `mailpit` |
+
+On the declared path this table does not apply: `db` and `storage` are ignored,
+and the Postgres and MinIO come from the declared `KyselyDatabase` and
+`ObjectStorage` instead.
 
 If `docker-compose.yml` is missing, a warning is printed and services are skipped.
 

--- a/apps/docs/guide/fullstack-init.md
+++ b/apps/docs/guide/fullstack-init.md
@@ -2,6 +2,20 @@
 
 A detailed walkthrough of everything `gkm init` does when scaffolding a fullstack application.
 
+::: warning This path has not moved to constructs yet
+A single-app project scaffolds `src/constructs/`, gets a `constructs` glob in
+its config, and has its containers reconciled from what it declares. The
+fullstack workspace does not: its per-app database roles are created by
+`docker/postgres/init.sh` and its URLs come from per-app secrets, neither of
+which reconcile knows about — so declaring only the API's half would leave the
+auth app pointing at a container that is no longer the one running.
+
+It moves once the auth app declares its own half, most likely as a
+`database.schema()` tenant of the API's database. Until then this page describes
+what `gkm init --template fullstack` actually produces. For the constructs
+model, see [Getting Started](/guide/getting-started).
+:::
+
 ## Overview
 
 The fullstack template creates a production-ready monorepo with three applications and two shared packages. It sets up authentication, database isolation, encrypted secrets, Docker services, and development tooling — all wired together and ready to run with a single `gkm dev` command.
@@ -227,7 +241,7 @@ export default defineWorkspace({
     //   dependencies: ['api', 'auth'],
     // },
   },
-  services: { db: true, cache: true },
+  services: { db: true, cache: true },  // the pre-constructs shape — see the note at the top
 });
 ```
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -1,10 +1,15 @@
 # Getting Started
 
+::: info Version
+This is the documentation for **next** — the line where the constructs paradigm
+lands. For the released line, see [v9](https://geekmidas.github.io/toolbox/).
+:::
+
 ## Prerequisites
 
 - Node.js >= 22.0.0
 - pnpm >= 10.13.1
-- Docker (for local services — PostgreSQL, Redis, MinIO, etc.)
+- Docker (for the local containers `gkm` derives from your constructs)
 
 ## Install the CLI
 
@@ -18,367 +23,427 @@ pnpm add -g @geekmidas/cli
 gkm init my-project
 ```
 
-### Interactive Setup
+---
 
-The init command walks you through project setup:
+## The Model: Everything Is a Construct
 
-```
-? Template:
-  ❯ API        — Single backend API with endpoints
-    Fullstack  — Monorepo with API + Next.js + shared models
+The thing worth learning first isn't a command — it's what changed underneath
+them.
 
-? Services (space to select):
-  ◉ PostgreSQL
-  ◉ Redis
-  ◉ Mailpit
-  ◉ MinIO
+A **construct** is one declaration in your application code that stands for a
+piece of infrastructure. A bucket, a database, a cache, a third-party
+credential, an API surface, a topic, a queue. You write it once, and three
+different consumers derive what they need from that one line:
 
-? Event backend:
-  ❯ pg-boss   — PostgreSQL job queue (no extra container)
-    SNS/SQS   — AWS via LocalStack
-    RabbitMQ  — AMQP broker
-    None
+| Derived | By whom | When |
+|---------|---------|------|
+| The function's **environment** | the framework | `gkm build` |
+| Its **runtime client** | the framework | first request |
+| The **infrastructure** — a container locally, a resource deployed | the target adapter | `gkm dev` / `gkm deploy` |
 
-? Deployment target:
-  ❯ Dokploy
-    Configure later
-```
+Before, each of those was written by hand, in a different file, and the only
+thing holding them together was a string literal typed three times:
 
-### Quick Start (non-interactive)
-
-```bash
-# All defaults: fullstack template, all services, pgboss, dokploy
-gkm init my-saas --template fullstack --yes
-
-# API-only
-gkm init my-api --template api --yes
+```ts
+// ❌ the old shape — a bucket declared three times
+// 1. app code: a hand-written Service reading UPLOADS_NAME
+// 2. sst.config.ts: new Storage(stack, 'uploads'), links, envVars
+// 3. gkm config: services: { storage: true } → a minio container
 ```
 
-### Templates
-
-| Template | Description |
-|----------|-------------|
-| `api` | Single backend API with endpoints, auth, database |
-| `fullstack` | Monorepo — API + Better Auth + Next.js + shared models |
-| `worker` | Background job processing with events, crons, subscribers |
-| `serverless` | AWS Lambda handlers |
-| `minimal` | Health endpoint only |
-
-::: info
-The interactive prompt shows **API** and **Fullstack** by default. Use `--template` to select others:
-```bash
-gkm init my-worker --template worker --yes
+```ts
+// ✅ now — one line, and all three derive from it
+export const uploads = new ObjectStorage('Uploads');
 ```
+
+Rename the construct and every consumer moves with it, because there is no
+string to keep in step.
+
+::: tip Read the design
+The full argument — the dependency edge, why triggers aren't dependencies, why
+permissions are the adapter's business and not the manifest's — is in
+[Constructs Paradigm](/guide/constructs-paradigm).
 :::
 
 ---
 
-## End-to-End: From Init to Running App
+## 1. Declare a Database
 
-This section walks through everything after `gkm init` — how credentials work, how services start, and how your app receives injected environment variables.
+```typescript
+// src/constructs/database.ts
+import { KyselyDatabase } from '@geekmidas/constructs/database/kysely';
+import type { Generated } from 'kysely';
 
-### 1. What `gkm init` Creates
+export interface Database {
+  users: {
+    id: Generated<string>;
+    name: string;
+    email: string;
+    created_at: Generated<Date>;
+  };
+}
 
-After init, your project has encrypted secrets already bootstrapped for the `development` stage:
-
-```
-my-project/
-├── .gkm/
-│   └── secrets/
-│       └── development.json   # encrypted credentials (safe to commit)
-├── gkm.config.ts              # workspace / app config
-├── docker-compose.yml         # local services
-└── ...
-```
-
-The key for decrypting `development.json` is stored separately at:
-
-```
-~/.gkm/my-project/development.key
+export const database = new KyselyDatabase<Database, 'Example'>('Example');
 ```
 
-This key **never** enters source control. The encrypted secrets file can be committed freely.
+That single statement replaces what used to be a hand-written `Service`, a
+`services: { db: true }` entry in the config, and a `DATABASE_URL` nobody could
+trace back to a container. It declares the logical database, its schema, the
+owner/runtime role split, and the Postgres major version — read by the local
+target as a container tag and by the AWS target as the RDS engine version, so
+the two can't drift apart the way they used to.
 
-### 2. What Gets Seeded Automatically
+::: warning Both type arguments or neither
+TypeScript has no partial type-argument inference, so
+`new KyselyDatabase<Database>('Example')` leaves the name at `string` and widens
+the service key. Pass both.
+:::
 
-`gkm init` generates and encrypts sane development defaults including:
+Point the config at it:
 
-| Secret | Value |
-|--------|-------|
-| `DATABASE_URL` | `postgres://...@localhost:5432/my-project` |
-| `REDIS_URL` | `redis://localhost:6379` |
-| `STORAGE_ACCESS_KEY_ID` | derived from MinIO default user |
-| `STORAGE_SECRET_ACCESS_KEY` | derived from MinIO default password |
-| `EVENT_PUBLISHER_CONNECTION_STRING` | pgboss connection string |
-| `EVENT_SUBSCRIBER_CONNECTION_STRING` | pgboss connection string |
-| `JWT_SECRET` | randomly generated |
-| `NODE_ENV` | `development` |
+```typescript
+// gkm.config.ts
+import { defineConfig } from '@geekmidas/cli/config';
 
-You can view them any time:
-
-```bash
-gkm secrets:show --stage development
+export default defineConfig({
+  // One glob, every kind of resource. A declared ObjectStorage would never be
+  // found by `routes:` or `crons:` — resources have no kind to be listed under.
+  constructs: './src/constructs/**/*.ts',
+  routes: './src/endpoints/**/*.ts',
+  envParser: './src/config/env#envParser',
+  logger: './src/config/logger',
+  runtime: 'node',
+  openapi: true,
+});
 ```
 
-### 3. Reconcile Services (First Run)
-
-Run `gkm setup` once after init (and after changing `services` in the config). It:
-- Starts Docker services with credentials injected from your stage secrets — each project gets its own isolated containers, so multiple projects can run concurrently without port or credential collisions
-- Creates the database, roles, and schemas
-- Sets up pgboss if `events: 'pgboss'`
-- Validates that all required secrets exist
-
-```bash
-gkm setup
-```
-
-### 4. Start the Dev Server
+Now run:
 
 ```bash
 gkm dev
 ```
 
-`gkm dev` decrypts your stage secrets and **injects them as environment variables** before starting each app and its Docker services. Your code accesses them via `process.env` — no `.env` files needed. Because secrets are injected dynamically, multiple projects can run simultaneously without collisions.
+Reconcile reads the glob, inspects every export of every matching module, and
+asks one structural question — *does it have an id, and can it declare?* From
+the answer it starts a Postgres container, creates the database, applies the
+roles and the schema, and injects `EXAMPLE_URL` before your server starts.
+Nothing lists `postgres` anywhere. **The construct is why a Postgres exists at
+all.**
 
-```
-[api]  Decrypting secrets (development)...
-[api]  Starting on http://localhost:3000
-[api]  Telescope: http://localhost:3000/__telescope
-[auth] Starting on http://localhost:3002
-[web]  Waiting for api, auth...
-[web]  Starting on http://localhost:3001
-```
-
-::: tip Multiple projects
-`gkm dev` and `gkm test` each spin up Docker services with project-scoped credentials. Running `gkm dev` in two different projects starts two independent PostgreSQL (and Redis, MinIO, etc.) containers — no manual port mapping needed.
+::: info Structural, not `instanceof`
+A construct from a linked workspace or a second copy in the lockfile is still a
+construct. `instanceof` is exactly the check that would say otherwise.
 :::
 
-### 5. How Credential Injection Works
-
-`gkm dev` (and `gkm exec`) use a preload script to inject secrets **before** your app code runs. The flow is:
-
-```
-~/.gkm/my-project/development.key
-         │
-         ▼ decrypt
-.gkm/secrets/development.json
-         │
-         ▼ AES-256-GCM
-globalThis.__gkm_credentials__  (set by preload)
-         │
-         ▼ read by
-@geekmidas/envkit Credentials
-         │
-         ▼ merged into
-EnvironmentParser.parse()
-```
-
-In your app code:
+## 2. Use It From an Endpoint
 
 ```typescript
-// apps/api/src/config/env.ts
+// src/endpoints/router.ts
+import { e } from '@geekmidas/constructs/endpoints';
+import logger from '../config/logger';
+import { database } from '../constructs/database';
+
+export const router = e
+  .logger(logger)
+  .database(database)
+  .authorizer('iam');
+```
+
+```typescript
+// src/endpoints/users.ts
+import { z } from 'zod';
+import { router } from './router';
+
+export const getUsers = router
+  .get('/users')
+  .output(z.object({ users: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    email: z.email(),
+  })) }))
+  .handle(async ({ db }) => {
+    const users = await db.selectFrom('users').selectAll().execute();
+    return { users };
+  });
+```
+
+`db` is typed from the construct's schema. The execution wrapper opens the
+transaction and puts it in the handler context — including the RLS context when
+you configure one.
+
+## 3. Depend On Things: `.dependsOn()`
+
+`.dependsOn()` takes **constructs**, records the edge, and dissolves each
+construct's client into the handler's services under the construct's own id:
+
+```typescript
+// src/constructs/uploads.ts
+import { ObjectStorage } from '@geekmidas/constructs/object-storage';
+
+export const uploads = new ObjectStorage('Uploads', { versioned: true });
+```
+
+```typescript
+// src/endpoints/avatars.ts
+import { uploads } from '../constructs/uploads';
+
+export const createAvatarUpload = router
+  .post('/avatars')
+  .body(z.object({ contentType: z.string(), contentLength: z.number() }))
+  .dependsOn([uploads])
+  .handle(async ({ body, services }) => {
+    // services.uploads exists and types *because of* the .dependsOn above
+    return services.uploads.getUploadURL({
+      path: `avatars/${crypto.randomUUID()}`,
+      contentType: body.contentType,
+      contentLength: body.contentLength,
+    });
+  });
+```
+
+From that one edge: the handler's env gets `UPLOADS_URL` at build, its client is
+bound on the first request, and the deploy target grants exactly the S3 access
+this function named — and nothing else. **Permissions are not a framework
+concept and are not in the manifest.** The manifest records what is depended on;
+what that implies on a given cloud belongs to the adapter.
+
+::: warning `.dependsOn()` takes constructs only
+A `Service` (`{ serviceName, register }`) doesn't match the shape. That's what
+keeps environment sniffing confined to the legacy `.services()` path instead of
+leaking back into the new one.
+:::
+
+---
+
+## The Construct Catalogue
+
+Everything below is real today. `import { X } from '@geekmidas/constructs/…'`:
+
+| Construct | Import | Handler gets | Local | Deployed |
+|---|---|---|---|---|
+| `KyselyDatabase` | `/database/kysely` | `db` — a typed Kysely client | Postgres container | RDS |
+| `ObjectStorage` | `/object-storage` | `StorageClient` — write, presign | MinIO | S3 |
+| `FileServer` | `/file-server` | storage client **plus** `url()` / `signedUrl()` | MinIO | S3 + CDN |
+| `Cache` | `/cache` | `CacheClient` | Redis / Postgres table | Upstash, ElastiCache, or the database |
+| `Credential` | `/credential` | the parsed, validated value | injected secret | secret manager |
+| `Email` | `/email` | a sender, typed by your templates | Mailpit | SES, Resend, or SMTP |
+| `Topic` | `/topic` | `topic.publisher` — a typed publisher | pg-boss / RabbitMQ / LocalStack | SNS |
+| `Queue` | `/queue` | `send()` | pg-boss / RabbitMQ / LocalStack | SQS |
+| `RestApi` | `/rest-api` | — (a surface) | the dev server | API Gateway |
+| `StaticSite` | `/site` | — (a surface) | the dev server | CDN |
+| `BetterAuth` | `/auth` | the auth server | container | provisioned |
+
+Thirteen declaration kinds in total. **The local target reconciles all
+thirteen; the AWS target provisions twelve** — `rest-api` is the one still
+outstanding. See [what is outstanding](https://github.com/geekmidas/toolbox/blob/main/docs/design/constructs-outstanding.md).
+
+### Derived constructs
+
+A database isn't only a database. The derived forms come off the parent, so the
+parent's id comes from the parent instead of from a string somebody has to keep
+in step:
+
+```typescript
+export const database = new KyselyDatabase<Database, 'Example'>('Example');
+
+export const replica = database.reader();       // ExampleReader — read-only role
+export const cache = database.cache();          // ExampleCache — a cache in this DB
+export const acme = database.schema<TenantDB, 'Acme'>('Acme');  // its own role and URL
+database.owner;                                 // the DDL role, for migrations
+```
+
+`reader()` is enforced by the reader role's grants, not by which endpoint it
+reaches — which is why it stays correct even where a stage runs a single
+instance and the reader resolves to the writer's address.
+
+### Credentials have a shape
+
+A **secret** is generated and rotated by the platform and is one opaque string.
+A **credential** is issued by someone else, arrives with several fields, and is
+worth validating on the way in:
+
+```typescript
+import { Credential } from '@geekmidas/constructs/credential';
+
+export const stripe = new Credential('Stripe', {
+  schema: z.object({ secretKey: z.string(), webhookSecret: z.string() }),
+});
+
+// in a handler — no await, already fetched and validated at registration
+.dependsOn([stripe])
+.handle(async ({ services }) => services.stripe.secretKey)
+```
+
+A malformed or half-set credential fails when the process starts, not on the
+first request that needs the one field somebody forgot.
+
+---
+
+## Triggers Are Not Dependencies
+
+A **trigger** is what causes a function to run. A **dependency** is what it
+consumes while running. Keeping them apart is what lets a subscriber need no
+permission on its topic at all — the subscription is created at deploy, and at
+runtime it only reads its own queue.
+
+```typescript
+// A topic: the event contract, and a derived typed publisher
+import { Topic } from '@geekmidas/constructs/topic';
+
+export const users = new Topic('users', {
+  'user.created': z.object({ userId: z.string(), email: z.email() }),
+});
+```
+
+```typescript
+// A subscriber — bound to the topic, granted nothing on it
+import { s } from '@geekmidas/constructs/subscribers';
+
+export const sendWelcome = s
+  .topic(users)
+  .subscribe(['user.created'])
+  .dependsOn([email])
+  .handle(async ({ events, services }) => { /* … */ });
+```
+
+```typescript
+// A queue worker — one queue, one consumer, one construct
+import { q } from '@geekmidas/constructs/queue';
+
+export const processOrder = q
+  .queue('orders')
+  .message(z.object({ orderId: z.string() }))
+  .dependsOn([database])
+  .handle(async ({ message, services }) => { /* … */ });
+```
+
+```typescript
+// A schedule
+import { c } from '@geekmidas/constructs/crons';
+
+export const dailyReport = c
+  .schedule('cron(0 6 * * *)')   // or rate(1 day)
+  .dependsOn([database, uploads])
+  .handle(async ({ services }) => { /* … */ });
+```
+
+Publishing is the only side that needs the topic's connection string, so only
+the producer gets it — `.publisher(users.publisher)` on the factory, or
+`.dependsOn([users])` where a handler publishes directly.
+
+---
+
+## Secrets and Credential Injection
+
+`gkm init` bootstraps encrypted secrets for the `development` stage:
+
+```
+my-project/
+├── .gkm/secrets/development.json   # encrypted — safe to commit
+├── gkm.config.ts
+└── src/constructs/
+```
+
+The decryption key lives outside the repo at
+`~/.gkm/my-project/development.key` and never enters source control.
+
+`gkm dev` and `gkm exec` decrypt and inject before your app code runs, via a
+preload that sets `globalThis.__gkm_credentials__`:
+
+```typescript
+// src/config/env.ts
 import { EnvironmentParser } from '@geekmidas/envkit';
 import { Credentials } from '@geekmidas/envkit/credentials';
 
 export const envParser = new EnvironmentParser({
   ...process.env,
-  ...Credentials,  // ← injected secrets merged here
+  ...Credentials,
 });
-
-export const config = envParser
-  .create((get) => ({
-    port: get('PORT').string().transform(Number).default(3000),
-    databaseUrl: get('DATABASE_URL').string().url(),
-    redisUrl: get('REDIS_URL').string(),
-  }))
-  .parse();
 ```
 
-`Credentials` resolves (in priority order):
-1. `globalThis.__gkm_credentials__` — set by `gkm dev`/`gkm exec` preload
-2. Build-time decryption via `GKM_MASTER_KEY` — for CI/CD and Docker builds
-3. Empty object — fallback when no credentials are available
+`Credentials` resolves in priority order:
 
-::: warning
-Never read secrets with `process.env` directly in production-critical paths. Always go through `EnvironmentParser` with `Credentials` merged in — this ensures the same code works in dev (preload injection) and production (build-time or runtime decryption).
+1. `globalThis.__gkm_credentials__` — set by the `gkm dev` / `gkm exec` preload
+2. Build-time decryption via `GKM_MASTER_KEY` — CI/CD and Docker builds
+3. An empty object
+
+::: tip You need this less than you used to
+Anything a construct provides — a database URL, a bucket URL, a cache endpoint —
+is derived and injected from the declaration. `EnvironmentParser` is for what's
+genuinely yours to configure, and `Credential` is for third-party values with a
+shape. Reach for a raw env key when neither fits.
 :::
 
-### 6. Running One-Off Commands with Secrets
-
-Use `gkm exec` to run any command with secrets injected:
+Managing them:
 
 ```bash
-# Run a migration with DATABASE_URL injected
-gkm exec -- pnpm db:migrate
-
-# Run a script with all dev secrets
-gkm exec -- node scripts/seed.ts
-
-# Open a psql shell with DATABASE_URL injected
-gkm exec -- psql $DATABASE_URL
-```
-
-### 7. Managing Secrets
-
-```bash
-# Add a new secret
 gkm secrets:set STRIPE_KEY sk_test_xxx --stage development
-
-# View all secrets (values masked)
 gkm secrets:show --stage development
-
-# Rotate the encryption key
 gkm secrets:rotate --stage development
-
-# Initialize a new stage (e.g., production)
 gkm secrets:init --stage production
 ```
 
-Production secrets use the same encrypted format but get a separate key at `~/.gkm/my-project/production.key`. In CI/CD, provide the key via `GKM_MASTER_KEY`.
-
 ---
 
-## Workspace Configuration
-
-The generated `gkm.config.ts` for the fullstack template:
-
-```typescript
-import { defineWorkspace } from '@geekmidas/cli/config';
-
-export default defineWorkspace({
-  name: 'my-saas',
-
-  apps: {
-    api: {
-      type: 'backend',
-      path: 'apps/api',
-      port: 3000,
-      routes: './src/endpoints/**/*.ts',
-      envParser: './src/config/env#envParser',
-      logger: './src/config/logger#logger',
-      openapi: { enabled: true },
-    },
-    auth: {
-      type: 'backend',
-      path: 'apps/auth',
-      port: 3002,
-      entry: './src/index.ts',
-      framework: 'better-auth',
-      envParser: './src/config/env#envParser',
-      logger: './src/config/logger#logger',
-    },
-    web: {
-      type: 'frontend',
-      framework: 'nextjs',
-      path: 'apps/web',
-      port: 3001,
-      dependencies: ['api', 'auth'],
-    },
-  },
-
-  shared: {
-    packages: ['packages/*'],
-    models: { path: 'packages/models', schema: 'zod' },
-  },
-
-  services: {
-    db: true,       // postgres:18-alpine
-    cache: true,    // redis:8-alpine
-    mail: true,     // Mailpit in dev, SMTP in production
-    storage: true,  // MinIO in dev, AWS S3 in production
-    events: 'pgboss', // pgboss | sns | rabbitmq
-  },
-
-  secrets: { enabled: true },
-});
-```
-
-### Services Reference
-
-| Key | Dev container | Production |
-|-----|---------------|------------|
-| `db: true` | `postgres:18-alpine` | Provisioned PostgreSQL |
-| `cache: true` | `redis:8-alpine` | Provisioned Redis |
-| `mail: true` | Mailpit | SMTP provider |
-| `storage: true` | MinIO | AWS S3 |
-| `events: 'pgboss'` | Reuses PostgreSQL | Reuses PostgreSQL |
-| `events: 'sns'` | LocalStack (SNS+SQS) | AWS SNS+SQS |
-| `events: 'rabbitmq'` | RabbitMQ | Provisioned RabbitMQ |
-
----
-
-## Create Your First Endpoint
-
-```typescript
-// apps/api/src/endpoints/users.ts
-import { e } from '@geekmidas/constructs/endpoints';
-import { z } from 'zod';
-
-export const listUsers = e
-  .get('/users')
-  .output(z.array(z.object({
-    id: z.string(),
-    name: z.string(),
-    email: z.string(),
-  })))
-  .handle(async () => {
-    return [
-      { id: '1', name: 'Alice', email: 'alice@example.com' },
-    ];
-  });
-```
-
-The endpoint is auto-discovered from the `routes` glob and available at `GET /users`.
-
-## Inject Services into Endpoints
-
-```typescript
-// apps/api/src/services/database.ts
-import type { Service } from '@geekmidas/services';
-import { Kysely, PostgresDialect } from 'kysely';
-import pg from 'pg';
-
-export const databaseService = {
-  serviceName: 'db' as const,
-  async register(envParser) {
-    const { databaseUrl } = envParser
-      .create((get) => ({ databaseUrl: get('DATABASE_URL').string() }))
-      .parse();
-    return new Kysely({
-      dialect: new PostgresDialect({ pool: new pg.Pool({ connectionString: databaseUrl }) }),
-    });
-  },
-} satisfies Service<'db', Kysely<Database>>;
-
-// apps/api/src/endpoints/users.ts
-export const listUsers = e
-  .get('/users')
-  .services([databaseService])
-  .handle(async ({ services }) => {
-    return await services.db.selectFrom('users').selectAll().execute();
-  });
-```
-
----
-
-## Build for Production
+## Running Locally
 
 ```bash
-# Build server application
+gkm dev                    # reconcile containers from constructs, then serve
+gkm exec -- pnpm db:migrate # one-off command with secrets injected
+gkm test                   # tests, with containers and secrets
+```
+
+Each project's containers are scoped to that project, so two `gkm dev` sessions
+in two repos don't collide on ports or credentials.
+
+---
+
+## Build and Deploy
+
+`gkm build` writes the **manifest** — the seam between build and run. It records
+every declaration and every edge; what a given cloud does with them is the
+target adapter's business.
+
+```bash
 gkm build --provider server --production
-
-# Generate Docker files
 gkm docker
-
-# Deploy (Dokploy)
 gkm deploy --stage production
 ```
+
+::: warning Deploy is not yet proven end to end
+The AWS target provisions twelve of the thirteen kinds and its decisions are
+unit-tested as pure functions, but **a stack has never come up**. `rest-api` on
+AWS is outstanding. The Dokploy/server path is the one to use today.
+:::
+
+---
+
+## Coming From v9
+
+Nothing stops working. Four things are on notice, all warn-and-honour:
+
+| Deprecated | Replacement |
+|---|---|
+| `.services([dbService])` with a hand-written `Service` | `.dependsOn([construct])` |
+| Per-kind globs (`routes`, `crons`, `subscribers`) | one `constructs` glob |
+| `q.queue(name)` | `new Queue(name)` |
+| Workspace `services: { db, cache, mail }` | the constructs that imply them |
+
+`services.cache`, `services.mail`, and `services.events` keep a narrower job —
+naming the *backend* (`'upstash' | 'elasticache' | 'db'`, `'ses' | 'resend' |
+'smtp'`, `'pgboss' | 'sns' | 'rabbitmq'`) rather than declaring that a resource
+exists.
+
+`export const e` still works and gains a surface named `api`, which matches the
+current single-gateway behaviour.
 
 ---
 
 ## Next Steps
 
-- [CLI Reference](/packages/cli) — All `gkm` commands
-- [Workspaces](/guide/workspaces) — Multi-app monorepo configuration
-- [Testing](/guide/testing) — Testing patterns
-- [Deployment](/guide/deployment) — Production deployment
+- [Constructs Paradigm](/guide/constructs-paradigm) — the full design
+- [@geekmidas/constructs](/packages/constructs) — every builder, in detail
+- [CLI Reference](/guide/cli-reference) — all `gkm` commands
+- [Development Server](/guide/dev-server) — how reconcile and hot-reload work
+- [Testing](/guide/testing) — testing endpoints, queues, and subscribers
+- [Deployment](/guide/deployment) — production deployment

--- a/apps/docs/guide/project-structure.md
+++ b/apps/docs/guide/project-structure.md
@@ -1,47 +1,92 @@
 # Project Structure
 
-The @geekmidas/toolbox monorepo is organized as follows:
+## A scaffolded project
+
+`gkm init` lays out a single-app project like this:
+
+```
+my-api/
+├── gkm.config.ts              # constructs glob, routes glob, backends
+├── src/
+│   ├── constructs/            # what this app declares
+│   │   ├── database.ts        # KyselyDatabase — why a Postgres exists
+│   │   ├── storage.ts         # ObjectStorage — why a MinIO exists
+│   │   ├── cache.ts           # Cache
+│   │   └── email.ts           # Email — why a Mailpit exists
+│   ├── endpoints/             # the routes glob
+│   │   ├── health.ts
+│   │   └── users/
+│   ├── db/migrations/         # applied by kysely-ctl or the test setup
+│   ├── router.ts              # the shared endpoint factory
+│   └── config/
+│       ├── env.ts             # EnvironmentParser + Credentials
+│       └── logger.ts
+├── test/                      # transaction-isolated suite + factories
+└── .gkm/                      # generated — compose, secrets, manifest
+```
+
+Two directories carry the model:
+
+- **`src/constructs/`** — one file per declaration. Everything else derives from
+  what is here: the containers `gkm dev` starts, the env keys the build writes,
+  and the cloud resources a deploy provisions.
+- **`src/endpoints/`** — the handlers, which reach those declarations by edge
+  (`.dependsOn([…])`) rather than by env key.
+
+`.gkm/` is generated and gitignored except for `secrets/`, which is encrypted
+and safe to commit.
+
+::: tip One glob, every kind
+`constructs: './src/constructs/**/*.ts'` is a convention, not a requirement —
+discovery inspects every export of every matching module and keeps the ones with
+an `id` that can `declare()`. Point it at `./src/**/*.ts` and colocate a bucket
+with the feature that uses it if you prefer.
+:::
+
+## A workspace
+
+```
+my-saas/
+├── gkm.config.ts              # defineWorkspace — apps, backends, deploy
+├── apps/
+│   ├── api/
+│   │   ├── src/constructs/    # this app's declarations
+│   │   └── src/endpoints/
+│   ├── auth/
+│   └── web/
+└── packages/
+    ├── models/                # shared schemas
+    └── ui/
+```
+
+Each app's `constructs` glob resolves against that app's own path, and reconcile
+reads all of them into one manifest. Apps share infrastructure by declaring
+derived forms of it — `database.schema()` for a schema of its own,
+`database.reader()` for read-only access — never by agreeing on a URL string.
+
+## The toolbox repo itself
 
 ```
 toolbox/
-├── packages/           # Core packages
-│   ├── api/           # REST API framework
-│   ├── testkit/       # Testing utilities
-│   └── envkit/        # Environment config parser
-├── apps/              # Applications
-│   └── docs/          # VitePress documentation
-├── turbo.json         # Turbo configuration
-├── pnpm-workspace.yaml
-├── tsdown.config.ts   # Build configuration
-├── vitest.config.ts   # Test configuration
-└── biome.json         # Linting and formatting
+├── packages/
+│   ├── constructs/    # endpoints, functions, crons, and the resource constructs
+│   ├── manifest/      # declarations, naming, derivation — the build/run seam
+│   ├── cli/           # gkm: reconcile, dev, build, deploy
+│   ├── cloud/         # deploy targets
+│   └── …              # audit, auth, cache, db, envkit, errors, events, …
+├── apps/
+│   ├── docs/          # this site
+│   └── example/       # a worked v10 app
+├── docs/design/       # the design docs, including the constructs paradigm
+└── turbo.json
 ```
 
-## Package Organization
+Built with **tsdown** (ESM + CJS), orchestrated by **Turbo**, linted and
+formatted by **Biome**.
 
-Each package follows a consistent structure:
-
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm lint
 ```
-packages/[name]/
-├── src/               # Source code
-│   ├── index.ts      # Main entry point
-│   └── ...           # Package-specific modules
-├── tests/            # Test files
-├── package.json      # Package manifest
-├── tsconfig.json     # TypeScript config
-└── README.md         # Package documentation
-```
-
-## Build System
-
-The project uses:
-- **tsdown** for building TypeScript packages (ESM + CJS)
-- **Turbo** for monorepo task orchestration
-- **Biome** for linting and formatting
-
-## Development Workflow
-
-1. Install dependencies: `pnpm install`
-2. Build all packages: `pnpm build`
-3. Run tests: `pnpm test`
-4. Check code quality: `pnpm lint`

--- a/apps/docs/guide/testing.md
+++ b/apps/docs/guide/testing.md
@@ -35,6 +35,43 @@ export default defineConfig({
 });
 ```
 
+### Where the test database comes from
+
+`gkm test` reconciles the **test** stage before the suite runs: the same
+containers `gkm dev` uses, with the resources named for the stage. So there is
+no `docker compose up` in a test script and no `DATABASE_URL` to set — a
+declared database is what makes a Postgres exist, and its URL is injected under
+the key that database publishes.
+
+```typescript
+// test/config.ts
+import { it as itVitest } from 'vitest';
+import { wrapVitestKyselyTransaction } from '@geekmidas/testkit/kysely';
+import { Kysely, PostgresDialect } from 'kysely';
+import pg from 'pg';
+import type { Database } from '../src/constructs/database.ts';
+
+const connection = new Kysely<Database>({
+  dialect: new PostgresDialect({
+    // `ORDERS_URL` for `new KyselyDatabase<Database, 'Orders'>('Orders')`.
+    pool: new pg.Pool({ connectionString: process.env.ORDERS_URL }),
+  }),
+});
+
+export const it = wrapVitestKyselyTransaction<Database>(itVitest, { connection });
+```
+
+Migrations connect as the **owner** role — `ORDERS_OWNER_URL`, the one that may
+create, alter, and drop. A handler is never given it: `.dependsOn()` takes
+constructs, and `.owner` is a `Service`, so a handler cannot ask for DDL rights
+at all.
+
+```bash
+gkm test                    # reconcile the test stage, then run
+gkm test --run --coverage   # once, with coverage
+GKM_AUTO_SETUP=1 gkm test   # CI: generate a fresh stage when none exists
+```
+
 ### Running Tests
 
 ```bash

--- a/apps/docs/guide/workspaces.md
+++ b/apps/docs/guide/workspaces.md
@@ -49,6 +49,9 @@ export default defineWorkspace({
       path: 'apps/api',
       type: 'backend',
       port: 3000,
+      // One glob, every kind — what reconcile reads to derive this app's
+      // containers. Resolved against the app's own path.
+      constructs: './src/constructs/**/*.ts',
       routes: './src/endpoints/**/*.ts',
       envParser: './src/config/env',
       logger: './src/config/logger',
@@ -69,11 +72,15 @@ export default defineWorkspace({
     },
   },
 
+  // What no construct implies.
+  //
+  // `db` and `storage` are derived from the declared KyselyDatabase and
+  // ObjectStorage and are ignored here, so the two cannot disagree. What is
+  // left is a backend selection.
   services: {
-    db: true,
-    cache: true,
-    mail: true,
-    events: 'pgboss', // or 'sns' or 'rabbitmq'
+    cache: true,      // or 'upstash' | 'elasticache' | 'db'
+    mail: true,       // or 'ses' | 'resend' | 'smtp'
+    events: 'pgboss', // or 'sns' | 'rabbitmq'
   },
 
   deploy: {
@@ -81,6 +88,14 @@ export default defineWorkspace({
   },
 });
 ```
+
+::: info Every app declares its own half
+Each app's `constructs` glob is resolved against that app's path, and reconcile
+reads all of them into one manifest. An app that shares a database with another
+declares a derived form of it — `database.schema()` for its own schema and role,
+or `database.reader()` for read-only access — rather than reaching for the same
+URL by string.
+:::
 
 ::: tip
 Use `defineWorkspace()` (not `defineConfig()`) for multi-app workspaces. The `defineWorkspace()` helper provides type-safe dependency validation — `dependencies` values are checked against the app names in your config.
@@ -95,6 +110,7 @@ Each app can have its own `gkm.config.ts`:
 import { defineConfig } from '@geekmidas/cli/config';
 
 export default defineConfig({
+  constructs: './src/constructs/**/*.ts',
   routes: './src/endpoints/**/*.ts',
   envParser: './src/config/env',
   logger: './src/config/logger',

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -14,22 +14,32 @@ hero:
       link: https://github.com/geekmidas/toolbox
 
 features:
+  - title: Everything Is a Construct
+    details: A database, bucket, cache, or credential is one declaration. The container, the environment, the client, and the cloud resource all derive from it.
+  - title: One Edge, Three Derivations
+    details: .dependsOn([uploads]) gives a handler its client, its environment, and exactly the cloud access it named — and nothing else.
   - title: Type-Safe APIs
     details: Build REST APIs with full TypeScript type inference using @geekmidas/constructs
-  - title: Testing Utilities
-    details: Comprehensive testing factories and utilities with @geekmidas/testkit
-  - title: Environment Config
-    details: Type-safe environment configuration parsing with @geekmidas/envkit
+  - title: Zero Hand-Wired Infra
+    details: gkm dev reconciles the containers your constructs imply. Nothing lists postgres anywhere.
 ---
 
 ::: warning YOU ARE READING THE IN-DEVELOPMENT DOCS
-This is the `main` line, where the **constructs paradigm** is being introduced —
-everything becomes a construct, and the `function → resource` dependency edge
-becomes the single primitive. See the [design RFC](/guide/constructs-paradigm).
+This is the `main` line, where the **constructs paradigm** lands: everything
+becomes a construct, and the `function → resource` dependency edge becomes the
+single primitive. The [design RFC](/guide/constructs-paradigm) argues it in
+full.
 
-The pages below still describe the **current** API. They are rewritten as each
-phase lands, so treat anything outside the RFC as v9 documentation until its
-page says otherwise.
+Rewritten for the new model: [Getting Started](/guide/getting-started),
+[Project Structure](/guide/project-structure),
+[@geekmidas/constructs](/packages/constructs),
+[@geekmidas/cli](/packages/cli), [Development Server](/guide/dev-server),
+[Workspaces](/guide/workspaces), [Testing](/guide/testing), and
+[Deployment](/guide/deployment).
+
+Still describing the pre-constructs shape:
+[Fullstack Init](/guide/fullstack-init) — its auth app has not declared its
+half yet — and [@geekmidas/cloud](/packages/cloud), the hand-written stack.
 
 **For released documentation, switch to [v9](https://geekmidas.github.io/toolbox/).**
 :::

--- a/apps/docs/packages/audit.md
+++ b/apps/docs/packages/audit.md
@@ -241,7 +241,8 @@ Set `.auditor()` and `.actor()` on an `EndpointFactory` so all endpoints inherit
 import { EndpointFactory } from '@geekmidas/constructs/endpoints';
 
 const api = new EndpointFactory()
-  .services([databaseService, auditStorageService])
+  .database(database)
+  .services([auditStorageService])
   .auditor(auditStorageService)
   .actor(({ session }) => ({ id: session.sub, type: 'user' }));
 
@@ -290,14 +291,17 @@ const auditStorageService = {
     return new KyselyAuditStorage<Database>({
       db: kyselyDb,
       tableName: 'audit_logs',
-      databaseServiceName: 'database', // matches the endpoint's database service
+      // Must match the endpoint's database service key. For
+      // `new KyselyDatabase<Database, 'Orders'>('Orders')` that is `orders` —
+      // the construct's id, uncapitalised.
+      databaseServiceName: 'orders',
     });
   },
 } satisfies Service<'auditStorage', KyselyAuditStorage<Database>>;
 
 const api = new EndpointFactory()
-  .services([databaseService, auditStorageService])
-  .database(databaseService)
+  .database(database)
+  .services([auditStorageService])
   .auditor(auditStorageService)
   .actor(({ session }) => ({ id: session.sub, type: 'user' }));
 

--- a/apps/docs/packages/cache.md
+++ b/apps/docs/packages/cache.md
@@ -2,6 +2,21 @@
 
 Unified caching interface with multiple backend implementations.
 
+::: tip Declare the cache
+A `CacheClient` is what a declared `Cache` hands back:
+
+```typescript
+import { Cache } from '@geekmidas/constructs/cache';
+
+export const sessions = new Cache('Sessions');
+```
+
+Where it lives — Upstash, ElastiCache, or a table in the database — is
+`services.cache` in `gkm.config.ts`, because the same application code caches
+into any of them. The scheme in the injected URL picks the driver, so an app
+caching in Postgres never resolves a Redis client.
+:::
+
 ## Installation
 
 ```bash

--- a/apps/docs/packages/cli.md
+++ b/apps/docs/packages/cli.md
@@ -12,6 +12,7 @@ pnpm add -g @geekmidas/cli
 
 ## Features
 
+- **Reconcile** — derive local containers, databases, roles, and buckets from the constructs an app declares
 - **Project scaffolding** with interactive prompts
 - Build AWS Lambda handlers from endpoint definitions
 - Generate OpenAPI specifications
@@ -506,6 +507,37 @@ When `services.events` is configured, additional credentials are generated:
 
 All event backends generate `EVENT_PUBLISHER_CONNECTION_STRING` and `EVENT_SUBSCRIBER_CONNECTION_STRING` for use with `@geekmidas/events`.
 
+## Reconcile
+
+`gkm dev`, `gkm test`, and `gkm setup` all call one convergent function.
+
+It reads the `constructs` glob, inspects every export of every matching module,
+and builds a manifest. From the manifest it computes the containers a stage
+needs, compares that against what is running, and applies the difference:
+allocating ports, writing `.gkm/docker-compose.yml`, starting containers,
+creating databases, roles, schemas, and buckets.
+
+```bash
+gkm setup    # reconcile only
+gkm dev      # reconcile, then serve
+gkm test     # reconcile the `test` stage, then run the suite
+```
+
+It is safe to run repeatedly because its blast radius is entirely local — this
+project's containers and this project's `.gkm/`. It allocates ports, writes
+compose, starts containers, and creates roles; it never seeds, resets, or drops.
+Nothing it does can reach a cloud.
+
+**One plan serves every stage.** `gkm dev` reconciles `development` and
+`gkm test` reconciles `test`; they differ only in what the resources are called,
+never in what infrastructure exists — so one container and one role pair serve
+both, and two projects can run at once without colliding on a port.
+
+::: info It only runs when there is something to read
+Reconcile is reached when at least one app configures a `constructs` glob.
+A project without one keeps the hand-written `docker-compose.yml` path.
+:::
+
 ## Configuration File
 
 Create a `gkm.config.ts` file in your project root:
@@ -514,8 +546,28 @@ Create a `gkm.config.ts` file in your project root:
 import { defineConfig } from '@geekmidas/cli/config';
 
 export default defineConfig({
+  // Constructs — one glob, every kind.
+  //
+  // What reconcile reads to derive the containers this app needs: a declared
+  // KyselyDatabase is why a Postgres exists, a declared ObjectStorage is why a
+  // MinIO does. A glob per kind could never find them — a resource has no kind
+  // to be listed under.
+  constructs: './src/constructs/**/*.ts',
+
   // Route files (glob pattern or partitioned config)
   routes: './src/endpoints/**/*.ts',
+
+  // What no construct implies.
+  //
+  // `db` and `storage` are deliberately absent: they are derived from the
+  // declarations above and are ignored here, so the two cannot disagree. What
+  // is left is a backend *selection* — where the cache lives, who delivers the
+  // mail, which broker carries events.
+  services: {
+    cache: true,          // or 'upstash' | 'elasticache' | 'db'
+    mail: true,           // or 'ses' | 'resend' | 'smtp'
+    events: 'pgboss',     // 'pgboss' | 'sns' | 'rabbitmq'
+  },
 
   // Environment parser module (named export)
   envParser: './src/config/env#envParser',
@@ -736,11 +788,11 @@ const ping = e
   .output(z.object({ message: z.string() }))
   .handle(async () => ({ message: 'pong' }));
 
-// Standard tier - uses auth and/or services
+// Standard tier - uses auth and/or dependencies
 const getUsers = router
   .get('/users')
-  .services([DatabaseService])
-  .handle(async ({ services }) => services.database.findAll());
+  .dependsOn([database])
+  .handle(async ({ services }) => services.orders.selectFrom('users').selectAll().execute());
 
 // Full tier - uses declarative audits
 const deleteUser = router
@@ -759,7 +811,15 @@ The `docker` configuration controls Docker file generation:
 | `imageName` | `string` | package name | Docker image name |
 | `baseImage` | `string` | `node:22-alpine` | Base Docker image |
 | `port` | `number` | `3000` | Container port |
-| `compose.services` | `string[]` | `[]` | Services for docker-compose |
+| `compose.services` | `string[]` | `[]` | Services for the generated deploy compose |
+
+::: warning Deploy-side only
+`docker.compose.services` describes the compose file `gkm docker` generates for
+a deployment. It does **not** decide what runs locally: `gkm dev` and `gkm test`
+reconcile the containers from the declared constructs and write their own
+`.gkm/docker-compose.yml`. Listing `postgres` here does not start one locally,
+and declaring a `KyselyDatabase` does — which is the point.
+:::
 
 **Available Compose Services:**
 
@@ -1113,12 +1173,29 @@ auth: {
 
 ### Services Configuration
 
-| Service | Key | Default Image | Environment Variables |
-|---------|-----|---------------|----------------------|
-| PostgreSQL | `db` | `postgres:18-alpine` | `DATABASE_URL` |
-| Redis | `cache` | `redis:8-alpine` | `REDIS_URL` |
-| Mailpit | `mail` | `axllent/mailpit` | `SMTP_HOST`, `SMTP_PORT`, `MAIL_FROM` |
-| MinIO | `storage` | `minio/minio:latest` | `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` |
+Two halves, and the split is the point: what **exists** is derived from the
+constructs an app declares, and what a stage **selects** stays here.
+
+| Key | Status | What it means |
+|-----|--------|---------------|
+| `db` | derived | Ignored. A declared `KyselyDatabase` is what starts a Postgres and publishes `<NAME>_URL`. |
+| `storage` | derived | Ignored. A declared `ObjectStorage` is what starts a MinIO and publishes `<NAME>_URL`. |
+| `mail` | selection | `true` (Mailpit locally) or `'ses' \| 'resend' \| 'smtp'` — who delivers it deployed. A declared `Email` is what starts a Mailpit. |
+| `cache` | selection | `true`, an image pin, or `'upstash' \| 'elasticache' \| 'db'` — where the cache lives. |
+| `events` | selection | `'pgboss' \| 'sns' \| 'rabbitmq'` — which broker carries events. |
+
+Derived keys are **ignored rather than obeyed**, deliberately: a config and a
+declaration that disagree is the failure this model exists to remove. Set the
+image pin here if you need a specific version; declare the construct to have the
+thing at all.
+
+| Container | Default image | Comes from |
+|-----------|---------------|------------|
+| PostgreSQL | `postgres:18-alpine` (major from the declaration) | a declared database |
+| MinIO | `minio/minio:latest` | a declared bucket |
+| Mailpit | `axllent/mailpit` | a declared email sender |
+| Redis | `redis:8-alpine` | `cache: 'elasticache'` |
+| serverless-redis-http | `hiett/serverless-redis-http` | `cache: 'upstash'` (the default) |
 
 ### Events Configuration
 

--- a/apps/docs/packages/cloud.md
+++ b/apps/docs/packages/cloud.md
@@ -4,6 +4,20 @@ SST (ion / Pulumi) integration: opinionated, linkable constructs that map 1:1 to
 deployable units and **validate their environment before deploy**, plus the
 runtime helpers that resolve linked resources into environment variables.
 
+::: warning The direction of travel
+This package is the **hand-written** infra layer: you instantiate its constructs
+in `sst.config.ts` and keep them in step with your application code by hand.
+The constructs paradigm moves that the other way — the app declares what it
+needs, `gkm build` writes a manifest, and the target provisions from it, so
+there is no second declaration to keep in step.
+
+The AWS target reads the manifest and covers twelve of the thirteen declaration
+kinds already (`rest-api` is outstanding, and nothing has been deployed end to
+end). Use this package where you still hand-write a stack; prefer declaring
+constructs in application code for anything new. See
+[Constructs Paradigm](/guide/constructs-paradigm).
+:::
+
 ## Installation
 
 ```bash

--- a/apps/docs/packages/constructs.md
+++ b/apps/docs/packages/constructs.md
@@ -10,6 +10,8 @@ pnpm add @geekmidas/constructs
 
 ## Features
 
+- ✅ Declared infrastructure — a database, bucket, cache, or credential is one statement
+- ✅ `.dependsOn()` — one edge derives the environment, the client, and the cloud access
 - ✅ Fluent endpoint builder pattern
 - ✅ Full TypeScript type inference
 - ✅ StandardSchema validation (Zod, Valibot, etc.)
@@ -41,8 +43,141 @@ pnpm add @geekmidas/constructs
 | `/hono` | Hono framework adapter (`HonoEndpoint`) |
 | `/aws` | AWS Lambda adaptors (API Gateway v1/v2, `AWSLambdaFunction`, `AWSLambdaSubscriber`, `AWSLambdaQueue`, `AWSScheduledFunction`) |
 | `/testing` | Testing utilities (`TestEndpointAdaptor`, `TestFunctionAdaptor`, `TestSubscriberAdaptor`, `TestQueueAdaptor`) |
+| `/construct` | The `Construct` interface, `Consumable`, and `Declaration` types |
+| `/database/kysely` | `KyselyDatabase` — a declared Postgres database, typed by its schema |
+| `/object-storage` | `ObjectStorage` — a declared bucket |
+| `/file-server` | `FileServer` — a domain that serves a bucket's objects |
+| `/cache` | `Cache` — a declared cache |
+| `/credential` | `Credential` — a third-party credential with a shape |
+| `/email` | `Email` — declared outbound mail |
+| `/rest-api` | `RestApi` — an API surface |
+| `/site` | `StaticSite` — a declared static site |
+| `/auth` | `BetterAuth` — a declared auth server |
 
 > **Service integrations moved:** the tRPC and Middy middlewares now live in [`@geekmidas/services`](/packages/services) (`@geekmidas/services/trpc`, `@geekmidas/services/middy`) since they depend only on `@geekmidas/services`, not on the constructs.
+
+## Constructs
+
+A **construct** is one declaration that stands for a piece of infrastructure. It
+is simultaneously an infrastructure *requirement* at build time, a runtime
+*capability*, and something other code can *consume* — which is why the
+interface has exactly three members:
+
+```typescript
+interface Construct<TName extends string = string, TClient = never> {
+  readonly id: TName;
+  declare(): Declaration[];
+  readonly service: [TClient] extends [never] ? never : Service<TName, TClient>;
+}
+```
+
+From that one declaration, three different owners derive three different things:
+
+| Derived | By whom | When |
+|---------|---------|------|
+| The function's **environment** | the framework | `gkm build` |
+| Its **runtime client** | the framework | first request |
+| The **infrastructure** — a container locally, a cloud resource deployed | the target adapter | `gkm dev` / `gkm deploy` |
+
+### The resource constructs
+
+```typescript
+import { KyselyDatabase } from '@geekmidas/constructs/database/kysely';
+import { ObjectStorage } from '@geekmidas/constructs/object-storage';
+import { Cache } from '@geekmidas/constructs/cache';
+import { Credential } from '@geekmidas/constructs/credential';
+
+export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
+export const uploads = new ObjectStorage('Uploads', { versioned: true });
+export const cache = new Cache('Sessions');
+export const stripe = new Credential('Stripe', {
+  schema: z.object({ secretKey: z.string(), webhookSecret: z.string() }),
+});
+```
+
+Each canonicalises its id — `uploads` and `Uploads` are one construct, not two
+that collide — and derives its env key from it: `UPLOADS_URL`, `SESSIONS_URL`,
+`ORDERS_URL` (plus `ORDERS_OWNER_URL` for the DDL role). The key the target
+publishes and the key the client reads come from the same field, so they cannot
+drift.
+
+| Construct | Import | The client it hands back |
+|---|---|---|
+| `KyselyDatabase` | `/database/kysely` | `Kysely<DB>`, typed by your schema |
+| `ObjectStorage` | `/object-storage` | `StorageClient` — write, delete, presign |
+| `FileServer` | `/file-server` | a `StorageClient` **superset** — plus `url()` and `signedUrl()` |
+| `Cache` | `/cache` | `CacheClient` |
+| `Credential` | `/credential` | the parsed, validated value — no `await` at the call site |
+| `Email` | `/email` | an `EmailClient` typed by your templates |
+| `Topic` | `/topic` | `topic.publisher` — a typed `EventPublisher` |
+| `Queue` | `/queue` | `send()` |
+| `RestApi` | `/rest-api` | — a surface; it owns a URL, not a client |
+| `StaticSite` | `/site` | — a surface |
+| `BetterAuth` | `/auth` | the auth server |
+
+### `.dependsOn()` — the one primitive
+
+Every builder takes it: endpoints, functions, crons, queue workers, and
+subscribers.
+
+```typescript
+export const createAvatar = e
+  .post('/avatars')
+  .dependsOn([uploads, stripe])
+  .handle(async ({ services }) => {
+    // Both exist, and both type, because of the edge above.
+    services.uploads.getUploadURL({ path, contentType, contentLength });
+    services.stripe.secretKey;
+  });
+```
+
+The edge records what a handler consumes. The framework derives its environment
+and its runtime binding; the deploy target separately derives cloud access from
+the same edge. **Permissions are not a framework concept and are not in the
+manifest** — what an edge implies on a given cloud is the adapter's business.
+
+`.dependsOn()` takes constructs only. A `Service` (`{ serviceName, register }`)
+does not match the shape, which is what keeps environment sniffing confined to
+`.services()`.
+
+A construct that owns no client — a `Cron`, a `Subscriber` — types its
+`service` as `never`, so depending on one is a compile error rather than a stub
+that throws at runtime. You cannot call a queue worker; you send to its queue.
+
+### The database, and what comes off it
+
+```typescript
+export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
+
+export const replica = database.reader();                    // OrdersReader
+export const cache = database.cache();                       // OrdersCache
+export const acme = database.schema<TenantDB, 'Acme'>('Acme'); // its own role + URL
+database.owner;                                              // the DDL role
+```
+
+`.database(database)` on a factory puts the client in the handler context as
+`db`, and the execution wrapper is what opens the transaction and applies the
+RLS context:
+
+```typescript
+export const router = e.logger(logger).database(database);
+
+export const listOrders = router
+  .get('/orders')
+  .handle(async ({ db }) => db.selectFrom('orders').selectAll().execute());
+```
+
+`.owner` is a `Service` rather than a construct, deliberately: `.dependsOn()`
+takes constructs, so a handler cannot ask for DDL rights at all. A migrator asks
+for it by name.
+
+::: tip Discovery
+Point `constructs: './src/constructs/**/*.ts'` at them in `gkm.config.ts`. One
+glob, every kind — a declared `ObjectStorage` has no kind to be listed under, so
+a glob per kind could never find it. Discovery inspects every export of every
+matching module and asks one structural question: does it have an `id`, and can
+it `declare()`?
+:::
 
 ## Basic Usage
 
@@ -110,9 +245,14 @@ throw createError.conflict('Resource already exists');
 throw createError.internalServerError('Something went wrong');
 ```
 
-### Service Pattern
+### Services — the escape hatch
 
-Define services as object literals with dependency injection:
+A `Service` is still how you reach something no construct describes: a
+third-party SDK, an internal client, anything you assemble yourself. Prefer a
+construct where one exists — a hand-written database service is the case the
+`KyselyDatabase` construct replaces, and it is the one the build cannot see
+into, since it has to *run* the service against a sniffer to learn which env
+keys it touches.
 
 ```typescript
 import type { Service } from '@geekmidas/constructs';
@@ -139,6 +279,16 @@ const endpoint = e
     return await db.query('...');
   });
 ```
+
+::: warning
+`.services()` with a hand-written resource service is deprecated — it still
+works and will keep working through this major. The database above is one line
+as a construct:
+
+```typescript
+export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
+```
+:::
 
 ## Advanced Usage
 
@@ -647,7 +797,8 @@ Set `.auditor()` and `.actor()` on an `EndpointFactory` so all endpoints inherit
 import { EndpointFactory } from '@geekmidas/constructs/endpoints';
 
 const api = new EndpointFactory()
-  .services([databaseService, auditStorageService])
+  .database(database)
+  .services([auditStorageService])
   .session(extractSession)
   .authorizer('jwt')
   .auditor(auditStorageService)
@@ -685,8 +836,8 @@ When the audit storage uses the same database as the endpoint (e.g., both use th
 
 ```typescript
 const api = new EndpointFactory()
-  .services([databaseService, auditStorageService])
-  .database(databaseService)
+  .database(database)
+  .services([auditStorageService])
   .auditor(auditStorageService)
   .actor(({ session }) => ({ id: session.sub, type: 'user' }));
 
@@ -714,7 +865,7 @@ const endpoint = api
 ```
 
 ::: tip
-When `.database()` is configured and the audit storage's `databaseServiceName` matches the endpoint's database service, the framework automatically wraps the handler and audit flush in a single transaction. No extra configuration is needed.
+When `.database()` is configured and the audit storage's `databaseServiceName` matches the endpoint's database, the framework automatically wraps the handler and the audit flush in a single transaction. No extra configuration is needed.
 :::
 
 ### Row Level Security (RLS)
@@ -729,8 +880,7 @@ Configure RLS once on the factory so all endpoints inherit it:
 import { EndpointFactory } from '@geekmidas/constructs/endpoints';
 
 const api = new EndpointFactory()
-  .services([databaseService])
-  .database(databaseService)
+  .database(database)
   .session(extractSession)
   .authorizer('jwt')
   .rls({
@@ -814,8 +964,7 @@ import { e } from '@geekmidas/constructs/endpoints';
 
 const endpoint = e
   .get('/orders')
-  .services([databaseService])
-  .database(databaseService)
+  .database(database)
   .rls({
     extractor: ({ session, header }) => ({
       user_id: session.userId,
@@ -874,8 +1023,8 @@ import { e } from '@geekmidas/constructs/endpoints';
 
 const createOrder = e
   .post('/orders')
-  .services([databaseService])
-  .publisher(eventPublisherService)
+  .dependsOn([database])
+  .publisher(orders.publisher)
   .body(orderSchema)
   .output(orderResponseSchema)
   .events([
@@ -959,14 +1108,37 @@ const createUser = e
 
 The connection string protocol determines which backend is used (`pgboss://`, `rabbitmq://`, `sns://`, `sqs://`, `basic://`). When using `services.events` in your workspace config, the CLI auto-generates this env var.
 
+::: tip A topic derives its publisher
+Writing the service above by hand is the case `Topic` removes. Declare the event
+contract and the producer comes off it, typed to the union of that topic's
+events:
+
+```typescript
+import { Topic } from '@geekmidas/constructs/topic';
+
+export const users = new Topic('users', {
+  'user.created': z.object({ userId: z.string(), email: z.email() }),
+});
+
+const createUser = e
+  .post('/users')
+  .publisher(users.publisher)   // derived, not hand-written
+  .event({ type: 'user.created', payload: (r) => ({ userId: r.id, email: r.email }) })
+  .handle(async ({ body }) => createUser(body));
+```
+
+A subscriber binds to the topic instead of depending on it — `s.topic(users)` —
+and is granted nothing on it, because at runtime it only reads its own queue.
+:::
+
 ### Factory-Level Publisher
 
 Set a default publisher on the factory so all endpoints inherit it:
 
 ```typescript
 const api = new EndpointFactory()
-  .services([databaseService])
-  .publisher(eventPublisherService);
+  .database(database)
+  .publisher(users.publisher);
 
 // All endpoints can use .event() without specifying .publisher()
 const createOrder = api
@@ -997,21 +1169,21 @@ export const onUserCreated = s
   });
 ```
 
-### With Services
+### With Dependencies
 
 ```typescript
 export const onOrderPlaced = s
-  .services([databaseService, emailService])
+  .dependsOn([database, email])
   .subscribe('order.placed')
   .handle(async ({ events, services, logger }) => {
     for (const event of events) {
-      const order = await services.database
+      const order = await services.orders
         .selectFrom('orders')
         .where('id', '=', event.payload.orderId)
         .selectAll()
         .executeTakeFirstOrThrow();
 
-      await services.email.send('order-confirmation', {
+      await services.email.sendTemplate('order-confirmation', {
         to: order.customerEmail,
         props: { orderId: order.id, total: order.total },
       });
@@ -1170,18 +1342,19 @@ export const ordersQueue = q
   });
 ```
 
-### With Services
+### With Dependencies
 
-Services are an **array** (the same shape endpoints/subscribers use) and are sniffed for the env vars they require — those flow into the manifest so infra provisions them:
+`.dependsOn()` names constructs. The edge is what the manifest records, and what
+a deploy target reads to grant this worker exactly what it named:
 
 ```typescript
 export const ordersQueue = q
   .queue('orders')
-  .services([databaseService])
+  .dependsOn([database])
   .message(z.object({ orderId: z.string() }))
   .handle(async ({ messages, services }) => {
     for (const { orderId } of messages) {
-      await services.database.fulfil(orderId);
+      await fulfil(services.orders, orderId);
     }
   });
 ```
@@ -1333,11 +1506,11 @@ c.schedule('cron(0 12 1 * *)')
 import { c } from '@geekmidas/constructs/crons';
 
 export const syncCron = c
-  .services([databaseService, cacheService])
+  .dependsOn([database, cache])
   .schedule('rate(30 minutes)')
   .handle(async ({ services, logger }) => {
-    const db = services.database;
-    const cache = services.cache;
+    const db = services.orders;
+    const kv = services.sessions;
 
     const staleRecords = await db
       .selectFrom('records')
@@ -1346,7 +1519,7 @@ export const syncCron = c
       .execute();
 
     for (const record of staleRecords) {
-      await cache.delete(`record:${record.id}`);
+      await kv.delete(`record:${record.id}`);
     }
 
     logger.info({ count: staleRecords.length }, 'Cache invalidated');
@@ -1384,8 +1557,7 @@ export const reportCron = c
 import { c } from '@geekmidas/constructs/crons';
 
 export const archiveCron = c
-  .services([databaseService])
-  .database(databaseService)
+  .database(database)
   .schedule('cron(0 2 * * *)')
   .handle(async ({ db, logger }) => {
     const cutoff = new Date(Date.now() - 90 * 24 * 3600000); // 90 days
@@ -1406,11 +1578,11 @@ export const archiveCron = c
 import { c } from '@geekmidas/constructs/crons';
 
 export const reminderCron = c
-  .services([databaseService])
-  .publisher(eventPublisherService)
+  .dependsOn([database])
+  .publisher(orders.publisher)
   .schedule('rate(1 hour)')
   .handle(async ({ services, publish }) => {
-    const users = await services.database
+    const users = await services.orders
       .selectFrom('users')
       .where('reminder_due', '<', new Date())
       .selectAll()

--- a/apps/docs/packages/db.md
+++ b/apps/docs/packages/db.md
@@ -2,6 +2,21 @@
 
 Database utilities for Kysely with flexible transaction management and Row Level Security (RLS) support.
 
+::: tip Declare the database, don't wire it
+`@geekmidas/db` is the toolkit — transactions, RLS helpers, migration
+utilities. The **connection** comes from a declared construct:
+
+```typescript
+import { KyselyDatabase } from '@geekmidas/constructs/database/kysely';
+
+export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
+```
+
+One statement gives you the container locally, the RDS instance deployed, the
+owner/runtime role split, the schema, and a typed client in every handler that
+names it. See [Getting Started](/guide/getting-started).
+:::
+
 ## Installation
 
 ```bash
@@ -115,6 +130,10 @@ await withTransaction(db, async (trx) => {
 ```
 
 ## Usage with Services
+
+The hand-written form, for reference — the
+[`KyselyDatabase` construct](/packages/constructs#the-database-and-what-comes-off-it)
+is one line and gives you the container and the roles as well.
 
 ```typescript
 import type { Service } from '@geekmidas/services';
@@ -334,8 +353,7 @@ When using `@geekmidas/constructs`, RLS integrates seamlessly with endpoints. Th
 import { EndpointFactory } from '@geekmidas/constructs/endpoints';
 
 const api = new EndpointFactory()
-  .services([databaseService])
-  .database(databaseService)  // Required: specify which service provides db
+  .database(database)  // the declared KyselyDatabase — `db` in every handler
   .authorizer('jwt')
   .rls({
     extractor: ({ session }) => ({
@@ -393,8 +411,7 @@ import { e } from '@geekmidas/constructs/endpoints';
 
 const endpoint = e
   .get('/orders')
-  .services([databaseService])
-  .database(databaseService)
+  .database(database)
   .rls({
     extractor: ({ session, header }) => ({
       user_id: session.userId,

--- a/apps/docs/packages/emailkit.md
+++ b/apps/docs/packages/emailkit.md
@@ -2,6 +2,20 @@
 
 Type-safe email sending with React template support.
 
+::: tip Declare the sender
+An `EmailClient` is what a declared `Email` hands back, typed by the templates
+you gave it:
+
+```typescript
+import { Email } from '@geekmidas/constructs/email';
+
+export const email = new Email('Mail', { templates: { welcome: WelcomeEmail } });
+```
+
+Every backend speaks SMTP, so the client never changes — Mailpit locally, SES,
+Resend, or your own SMTP deployed, selected by `services.mail`.
+:::
+
 ## Installation
 
 ```bash

--- a/apps/docs/packages/envkit.md
+++ b/apps/docs/packages/envkit.md
@@ -2,6 +2,18 @@
 
 Type-safe environment configuration parser using Zod validation.
 
+::: tip You need this less than you used to
+`EnvironmentParser` is for configuration that is genuinely yours — a port, a
+feature flag, a tunable. Anything a construct provides is derived and injected
+under a key the construct owns (`ORDERS_URL`, `UPLOADS_URL`), and reached
+through `.dependsOn()` rather than by parsing a key by hand; a third-party
+credential with several fields is a
+[`Credential`](/packages/constructs#constructs), validated at registration.
+
+`Credentials` from `@geekmidas/envkit/credentials` stays exactly as it is — it
+is how the encrypted stage secrets reach the parser.
+:::
+
 ## Installation
 
 ```bash

--- a/apps/docs/packages/events.md
+++ b/apps/docs/packages/events.md
@@ -2,6 +2,24 @@
 
 Unified event messaging library with support for multiple backends.
 
+::: tip Topics and queues are constructs
+A publisher service written by hand is the case `Topic` removes — declare the
+event contract and the typed producer comes off it:
+
+```typescript
+import { Topic } from '@geekmidas/constructs/topic';
+
+export const users = new Topic('users', {
+  'user.created': z.object({ userId: z.string(), email: z.email() }),
+});
+
+users.publisher;   // an EventPublisher typed to this topic's events
+```
+
+This package is what those constructs are built on, and what you reach for
+directly when you are wiring a broker yourself.
+:::
+
 ## Installation
 
 ```bash
@@ -202,7 +220,7 @@ The dev server discovers your subscribers, connects to pg-boss, and begins polli
 
 ### Event Backend Setup
 
-When PostgreSQL is enabled (`db: true`), the CLI automatically sets up **pg-boss** as the default event backend — no explicit configuration needed. A dedicated `pgboss` user and schema are created in your PostgreSQL database, and `EVENT_PUBLISHER_CONNECTION_STRING` / `EVENT_SUBSCRIBER_CONNECTION_STRING` are set automatically.
+When a database is declared, the CLI automatically sets up **pg-boss** as the default event backend — no explicit configuration needed. A dedicated `pgboss` user and schema are created in your PostgreSQL database, and `EVENT_PUBLISHER_CONNECTION_STRING` / `EVENT_SUBSCRIBER_CONNECTION_STRING` are set automatically.
 
 To use a different backend, set `events` explicitly:
 
@@ -213,10 +231,9 @@ import { defineWorkspace } from '@geekmidas/cli';
 export default defineWorkspace({
   apps: { /* ... */ },
   services: {
-    db: true,
-    // events defaults to pgboss when db is enabled
-    // Override with 'sns' or 'rabbitmq' for a different backend:
-    // events: 'sns',
+    // pgboss is the default. It reuses the Postgres your declared database
+    // already brings up — `db: true` is not needed and is ignored.
+    // events: 'sns',      // or 'rabbitmq'
   },
 });
 ```
@@ -329,12 +346,12 @@ Use the `s` builder from `@geekmidas/constructs/subscribers`:
 import { s } from '@geekmidas/constructs/subscribers';
 
 export const onUserCreated = s
-  .services([databaseService, emailService])
-  .publisher(eventPublisherService) // optional, for chaining events
+  .dependsOn([database, email])
+  .publisher(orders.publisher) // optional, for chaining events
   .subscribe('user.created')
   .handle(async ({ events, services, logger }) => {
     for (const event of events) {
-      await services.email.send('welcome', { to: event.payload.email });
+      await services.mail.sendTemplate('welcome', { to: event.payload.email });
       logger.info({ userId: event.payload.userId }, 'Welcome email sent');
     }
   });
@@ -371,9 +388,9 @@ When PostgreSQL is enabled, the CLI automatically creates pgboss credentials and
 ```typescript
 // gkm.config.ts
 export default defineWorkspace({
-  services: {
-    db: true, // pgboss event backend is created automatically
-  },
+  // Nothing to configure: pgboss is the default, and it lives in the Postgres
+  // your declared database already implies.
+  services: {},
 });
 ```
 
@@ -386,7 +403,6 @@ For SNS or RabbitMQ, set `events` explicitly — the CLI then adds the appropria
 
 ```typescript
 services: {
-  db: true,
   events: 'sns',      // adds LocalStack, uses sns:// and sqs:// protocols
   // events: 'rabbitmq', // adds RabbitMQ, uses rabbitmq:// protocol
 },

--- a/apps/docs/packages/manifest.md
+++ b/apps/docs/packages/manifest.md
@@ -1,0 +1,127 @@
+# @geekmidas/manifest
+
+The seam between build and run: the declaration types every construct emits, the
+naming rules every key derives from, and the graph functions a target reads.
+
+One runtime dependency (`lodash.snakecase`) and no framework imports, on
+purpose — the producer (`@geekmidas/cli`) and the consumers (deploy targets)
+share a data contract, not a library.
+
+## Installation
+
+```bash
+pnpm add @geekmidas/manifest
+```
+
+You rarely import it directly. A construct resolves its own env key through it,
+and `gkm build` writes a manifest with it; you reach for it when writing a
+target, a codegen step, or a construct of your own.
+
+## The manifest
+
+Every construct, keyed by its id:
+
+```typescript
+import type { ConstructManifest } from '@geekmidas/manifest';
+
+const manifest = {
+  Orders: { kind: 'database', id: 'Orders', engine: 'postgres', schema: 'app',
+            version: 18, provides: ['ORDERS_URL'] },
+  Uploads: { kind: 'objects', id: 'Uploads', provides: ['UPLOADS_URL'] },
+} as const satisfies ConstructManifest;
+```
+
+Flat rather than grouped, because a dependency resolves as `manifest[target]` —
+an O(1) lookup that is identical whether the edge points at a resource, a
+surface, or another function.
+
+Use it as a **constraint, not an annotation**: `as const satisfies
+ConstructManifest` checks the shape while keeping the literal types, so
+`IdsOf<typeof manifest>` is `'Orders' | 'Uploads'` rather than `string`.
+
+## Declaration kinds
+
+Thirteen, as a discriminated union — exhaustiveness *and* per-kind fields, with
+no shape carrying a field that belongs to a different kind:
+
+| Kind | Declared by | Notes |
+|------|-------------|-------|
+| `database` | `KyselyDatabase` | `engine`, `schema`, `version`, `roles` |
+| `database-reader` | `database.reader()` | derives from a database or a schema tenant |
+| `database-schema` | `database.schema()` | its own role and URL |
+| `objects` | `ObjectStorage` | `versioned` |
+| `file-server` | `FileServer` | derives from `objects` — it shares the parent's *contents*, not its credentials |
+| `cache` | `Cache` | `of` when it lives in a database |
+| `email` | `Email` | |
+| `secret` | — | platform-generated, one opaque string |
+| `credential` | `Credential` | third-party, several fields, validated |
+| `rest-api` | `RestApi` | `authorizers`, `defaultAuthorizer`, nested `endpoints` |
+| `site` | `StaticSite` | `variant` selects how values are delivered |
+| `topic` | `Topic` | `events`, nested `subscribers` |
+| `queue` | `Queue` | `fifo`, nested `worker` |
+| `function` / `cron` | `f` / `c` | carry a `handler` |
+
+Triggered functions **nest inside the surface that triggers them**, so there is
+no `trigger` field — position carries it.
+
+### What is not in it
+
+**Permissions.** The manifest records what is depended on; what that implies on
+a given cloud — an IAM policy, a security group, a link — is the target
+adapter's business. A portable contract that named `sns:Publish` would not be
+portable.
+
+## Naming
+
+Every key in the system comes from these four functions, which is what keeps the
+key a target publishes and the key a client reads from drifting apart:
+
+```typescript
+import { canonicalId, provideKey, serviceKey, cloudName } from '@geekmidas/manifest';
+
+canonicalId('user-uploads');            // 'UserUploads'  — PascalCase
+provideKey('Uploads', 'url');           // 'UPLOADS_URL'
+provideKey('Orders', 'ownerUrl');       // 'ORDERS_OWNER_URL'
+serviceKey('Uploads');                  // 'uploads'      — the handler's key
+cloudName({ stage: 'prod', app: 'shop' }, 'UserUploads');
+// 'prod-shop-user-uploads'
+```
+
+`uploads`, `Uploads`, `user_uploads`, and `user-uploads` all canonicalise to the
+same id, so declaring two of them is a duplicate rather than a collision to
+detect later. Ids are narrower than JavaScript identifiers — `_id` and `$ref`
+are rejected — because an id also has to survive `environmentCase` into an env
+key and `cloudName` into a DNS-safe resource name.
+
+`serviceKey` is the runtime twin of the type-level `Uncapitalize<TName>`; the
+two must agree exactly, which is why the id is written in PascalCase.
+
+## Graph functions
+
+```typescript
+import {
+  provisionOrder,
+  dependenciesOf,
+  dependentsOf,
+  assertDerivations,
+  isDerived,
+  publicEnvFor,
+} from '@geekmidas/manifest';
+
+provisionOrder(manifest);       // parents before children
+dependenciesOf(manifest, 'ListOrders');
+dependentsOf(manifest, 'Orders');
+assertDerivations(manifest);    // a child naming a parent that cannot be one throws
+```
+
+Resources stay leaves — a resource may not consume another construct — which
+keeps the provisioning graph acyclic. `DERIVES_FROM` states exhaustively what
+each derived kind may derive from, so cycles are impossible without a graph
+walk: readers are terminal, and there is no `writer`, because the database *is*
+the writer.
+
+## See also
+
+- [Constructs Paradigm](/guide/constructs-paradigm) — the design this implements
+- [@geekmidas/constructs](/packages/constructs#constructs) — what emits these declarations
+- [@geekmidas/cli](/packages/cli#reconcile) — what reads them locally

--- a/apps/docs/packages/services.md
+++ b/apps/docs/packages/services.md
@@ -2,6 +2,17 @@
 
 Service discovery and dependency injection system.
 
+::: tip A construct is the better answer for infrastructure
+`Service` is unchanged and is not going anywhere — it is how you reach a
+third-party SDK or a client you assemble yourself. But a database, bucket,
+cache, mail sender, or third-party credential is a **construct**: one
+declaration that yields the infrastructure, the environment, and the client
+together, instead of a service that reads a URL somebody else has to provision.
+
+`.dependsOn()` takes constructs only; `.services()` takes these. See
+[@geekmidas/constructs](/packages/constructs#constructs).
+:::
+
 ## Installation
 
 ```bash
@@ -106,10 +117,11 @@ import { e } from '@geekmidas/constructs/endpoints';
 
 export const endpoint = e
   .get('/users/:id')
-  .services([databaseService, cacheService])
+  .dependsOn([database, cache])          // constructs
+  .services([featureFlagService])        // hand-written services
   .handle(async ({ params, services }) => {
-    // Type-safe access to services
-    const cached = await services.cache.get(`user:${params.id}`);
+    // Type-safe access to both
+    const cached = await services.sessions.get(`user:${params.id}`);
     if (cached) return cached;
 
     const user = await services.database.users.findById(params.id);

--- a/apps/docs/packages/storage.md
+++ b/apps/docs/packages/storage.md
@@ -2,6 +2,22 @@
 
 Cloud storage abstraction layer with provider-agnostic API.
 
+::: tip Declare the bucket
+A `StorageClient` is what a declared `ObjectStorage` hands back — you rarely
+construct one by hand:
+
+```typescript
+import { ObjectStorage } from '@geekmidas/constructs/object-storage';
+
+export const uploads = new ObjectStorage('Uploads', { versioned: true });
+```
+
+`.dependsOn([uploads])` is what makes `services.uploads` exist and type, and
+what tells the deploy target to grant that handler S3 access and nothing else.
+Use [`FileServer`](/packages/constructs) instead when the objects are also
+served on a domain.
+:::
+
 ## Installation
 
 ```bash

--- a/packages/cli/scripts/sync-versions.ts
+++ b/packages/cli/scripts/sync-versions.ts
@@ -25,6 +25,7 @@ const PACKAGES = [
 	'errors',
 	'events',
 	'logger',
+	'manifest',
 	'rate-limit',
 	'schema',
 	'services',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -71,7 +71,9 @@ program
 
 program
 	.command('setup')
-	.description('Setup development environment (secrets, Docker, database)')
+	.description(
+		'Reconcile declared constructs — containers, databases, buckets, secrets',
+	)
 	.option('--stage <stage>', 'Stage name', 'development')
 	.option('--force', 'Regenerate secrets even if they exist')
 	.option('--skip-docker', 'Skip starting Docker services')
@@ -91,7 +93,7 @@ program
 
 program
 	.command('build')
-	.description('Build handlers from endpoints, functions, and crons')
+	.description('Build handlers and the manifest from declared constructs')
 	.option(
 		'--provider <provider>',
 		'Target provider for generated handlers (aws, server)',
@@ -174,7 +176,9 @@ program
 
 program
 	.command('dev')
-	.description('Start development server with automatic reload')
+	.description(
+		'Reconcile constructs and start the dev server with automatic reload',
+	)
 	.option('-p, --port <port>', 'Port to run the development server on')
 	.option('--entry <file>', 'Entry file to run (bypasses gkm config)')
 	.option('--watch', 'Watch for file changes (default: true with --entry)')

--- a/packages/cli/src/init/__tests__/generators.spec.ts
+++ b/packages/cli/src/init/__tests__/generators.spec.ts
@@ -958,18 +958,25 @@ describe('generateTestFiles', () => {
 		expect(configFile).toBeDefined();
 		expect(configFile!.content).toContain('wrapVitestKyselyTransaction');
 		expect(configFile!.content).toContain('@geekmidas/testkit/kysely');
-		expect(configFile!.content).toContain('~/services/database.ts');
+		// The declared database's schema type, and the key it publishes.
+		expect(configFile!.content).toContain('../src/constructs/database.ts');
+		expect(configFile!.content).toContain('process.env.TEST_PROJECT_URL');
 	});
 
-	it('should use PostgresKyselyMigrator with runInitScript in globalSetup', () => {
+	it('should migrate as the owner role in globalSetup', () => {
 		const files = generateTestFiles(baseOptions, minimalTemplate);
 		const setupFile = files.find((f) => f.path === 'test/globalSetup.ts');
 		expect(setupFile).toBeDefined();
 		expect(setupFile!.content).toContain('PostgresKyselyMigrator');
-		expect(setupFile!.content).toContain('runInitScript');
-		expect(setupFile!.content).toContain('afterCreate');
 		expect(setupFile!.content).toContain('Credentials');
-		expect(setupFile!.content).toContain('PGBOSS_DB_PASSWORD');
+
+		// Migrations connect as the DDL role the database construct declares.
+		expect(setupFile!.content).toContain('TEST_PROJECT_OWNER_URL');
+
+		// Reconcile creates the roles before the suite runs, so there is no init
+		// script left to run and no per-app password to thread through it.
+		expect(setupFile!.content).not.toContain('runInitScript');
+		expect(setupFile!.content).not.toContain('PGBOSS_DB_PASSWORD');
 	});
 
 	it('should use KyselyFactory in factory files', () => {

--- a/packages/cli/src/init/__tests__/init.spec.ts
+++ b/packages/cli/src/init/__tests__/init.spec.ts
@@ -109,9 +109,24 @@ describe('initCommand', () => {
 			expect(existsSync(join(projectDir, 'src/endpoints/users/get.ts'))).toBe(
 				true,
 			);
-			expect(existsSync(join(projectDir, 'src/services/database.ts'))).toBe(
+			// The database is a construct, not a hand-written service.
+			expect(existsSync(join(projectDir, 'src/constructs/database.ts'))).toBe(
 				true,
 			);
+			expect(existsSync(join(projectDir, 'src/services/database.ts'))).toBe(
+				false,
+			);
+
+			const database = await readFile(
+				join(projectDir, 'src/constructs/database.ts'),
+				'utf-8',
+			);
+			expect(database).toContain('KyselyDatabase');
+			expect(database).toContain("new KyselyDatabase<Database, 'MyApi'>");
+
+			// And the config points reconcile at it.
+			const config = await readFile(join(projectDir, 'gkm.config.ts'), 'utf-8');
+			expect(config).toContain("constructs: './src/constructs/**/*.ts'");
 		});
 
 		it('should create serverless template with functions', async () => {

--- a/packages/cli/src/init/constructs.ts
+++ b/packages/cli/src/init/constructs.ts
@@ -1,0 +1,142 @@
+/**
+ * What a scaffolded project declares, and the keys that derive from it.
+ *
+ * One place, because three generators need the same three facts: the template
+ * writes `new KyselyDatabase<Database, 'Acme'>('Acme')`, the test setup reads
+ * `ACME_OWNER_URL` to migrate, and Studio reads `ACME_URL` to connect. Deriving
+ * all of them from `@geekmidas/manifest`'s own helpers is what keeps a
+ * scaffolded project agreeing with the runtime that discovers it — the same
+ * reason the constructs own both faces at runtime.
+ */
+
+import { canonicalId, provideKey, serviceKey } from '@geekmidas/manifest';
+import type { GeneratedFile } from './templates/index.js';
+
+/** The glob every generated config points at. One glob, every kind. */
+export const CONSTRUCTS_GLOB = './src/constructs/**/*.ts';
+
+export interface ScaffoldedConstruct {
+	/** The canonical id — what the construct is declared under. */
+	id: string;
+	/** The key it is reached under in a handler's service record. */
+	service: string;
+	/** The runtime URL key the target publishes. */
+	urlKey: string;
+}
+
+export interface ScaffoldedDatabase extends ScaffoldedConstruct {
+	/** The DDL role's URL — what migrations connect as. */
+	ownerUrlKey: string;
+}
+
+/**
+ * The database a project named `name` declares.
+ *
+ * Named after the project rather than `Db`, so two apps in one workspace can
+ * declare one each without colliding on an id or on an env key.
+ */
+export function databaseFor(name: string): ScaffoldedDatabase {
+	const id = canonicalId(name);
+
+	return {
+		id,
+		service: serviceKey(id),
+		urlKey: provideKey(id, 'url'),
+		ownerUrlKey: provideKey(id, 'ownerUrl'),
+	};
+}
+
+/** The bucket a project named `name` declares. */
+export function storageFor(name: string): ScaffoldedConstruct {
+	const id = canonicalId(`${name}-uploads`);
+
+	return { id, service: serviceKey(id), urlKey: provideKey(id, 'url') };
+}
+
+/** The mail sender a project named `name` declares. */
+export function emailFor(name: string): ScaffoldedConstruct {
+	const id = canonicalId(`${name}-mail`);
+
+	return { id, service: serviceKey(id), urlKey: provideKey(id, 'url') };
+}
+
+/** The cache a project named `name` declares. */
+export function cacheFor(name: string): ScaffoldedConstruct {
+	const id = canonicalId(`${name}-cache`);
+
+	return { id, service: serviceKey(id), urlKey: provideKey(id, 'url') };
+}
+
+/**
+ * The files a project's declared database needs.
+ *
+ * Shared by every template, so a worker and an API declare the same database
+ * the same way — and so the schema type, the migration, and the id the test
+ * setup reads all come from one place.
+ */
+export function databaseFiles(name: string): GeneratedFile[] {
+	const db = databaseFor(name);
+
+	return [
+		{
+			path: 'src/constructs/database.ts',
+			content: `import { KyselyDatabase } from '@geekmidas/constructs/database/kysely';
+import type { Generated } from 'kysely';
+
+/** Your database schema. Add tables here. */
+export interface Database {
+  users: {
+    id: Generated<string>;
+    name: string;
+    email: string;
+    created_at: Generated<Date>;
+  };
+}
+
+/**
+ * The app's database, declared once.
+ *
+ * The container, the database inside it, its roles and schema, and
+ * \`${db.urlKey}\` all derive from this line — \`gkm dev\` reconciles them
+ * before the server starts, which is why nothing lists \`postgres\` anywhere.
+ *
+ * Both type arguments or neither: TypeScript has no partial type-argument
+ * inference, so passing only \`Database\` would leave the name at \`string\`
+ * and widen the service key away from \`${db.service}\`.
+ */
+export const database = new KyselyDatabase<Database, '${db.id}'>('${db.id}');
+`,
+		},
+		{
+			// The table the scaffolded endpoints and factories expect. Applied by
+			// `gkm exec -- pnpm kysely migrate:latest`, or by the test setup.
+			path: 'src/db/migrations/001_create_users.ts',
+			content: `import type { Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('users')
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(db.fn('gen_random_uuid')),
+    )
+    .addColumn('name', 'varchar(255)', (col) => col.notNull())
+    .addColumn('email', 'varchar(255)', (col) => col.notNull().unique())
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(db.fn('now')),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex('users_email_idx')
+    .on('users')
+    .column('email')
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('users').execute();
+}
+`,
+		},
+	];
+}

--- a/packages/cli/src/init/generators/config.ts
+++ b/packages/cli/src/init/generators/config.ts
@@ -1,3 +1,4 @@
+import { CONSTRUCTS_GLOB } from '../constructs.js';
 import type {
 	GeneratedFile,
 	TemplateConfig,
@@ -60,7 +61,15 @@ export function generateConfigFiles(
 	// Build gkm.config.ts for single-app
 	let gkmConfig = `import { defineConfig } from '@geekmidas/cli/config';
 
-export default defineConfig({
+export default defineConfig({${
+		options.monorepo
+			? ''
+			: `
+  // One glob, every kind. What reconcile reads to derive the containers this
+  // app needs: a declared database is why a Postgres exists at all, so nothing
+  // lists \`postgres\` anywhere.
+  constructs: '${CONSTRUCTS_GLOB}',`
+	}
   routes: '${getRoutesGlob()}',
   envParser: './src/config/env#envParser',
   logger: './src/config/logger#logger',`;
@@ -68,6 +77,34 @@ export default defineConfig({
 	if (isServerless || hasWorker) {
 		gkmConfig += `
   functions: './src/functions/**/*.ts',`;
+	}
+
+	// What no construct implies. `db` and `storage` are deliberately absent —
+	// the declared KyselyDatabase and ObjectStorage are what bring up the
+	// Postgres and the MinIO, and reconcile ignores those keys rather than
+	// obeying them so the two cannot disagree. What is left is a backend
+	// selection.
+	if (!options.monorepo) {
+		const { cache, mail, events } = options.services;
+
+		if (cache || mail || events) {
+			gkmConfig += `
+  services: {`;
+			if (cache) {
+				gkmConfig += `
+    cache: true,`;
+			}
+			if (mail) {
+				gkmConfig += `
+    mail: true,`;
+			}
+			if (events) {
+				gkmConfig += `
+    events: '${events}',`;
+			}
+			gkmConfig += `
+  },`;
+		}
 	}
 
 	if (hasWorker) {

--- a/packages/cli/src/init/generators/package.ts
+++ b/packages/cli/src/init/generators/package.ts
@@ -14,7 +14,7 @@ export function generatePackageJson(
 	options: TemplateOptions,
 	template: TemplateConfig,
 ): GeneratedFile[] {
-	const { name, telescope, database, studio, monorepo } = options;
+	const { name, telescope, database, studio, monorepo, services } = options;
 
 	// Start with template dependencies
 	const dependencies = { ...template.dependencies };
@@ -29,6 +29,37 @@ export function generatePackageJson(
 
 	if (studio) {
 		dependencies['@geekmidas/studio'] = GEEKMIDAS_VERSIONS['@geekmidas/studio'];
+	}
+
+	// Only a project that declares constructs needs them. The workspace path
+	// still reaches its infrastructure through hand-written services.
+	const declares = !monorepo;
+
+	// Every construct resolves its env key through the manifest, so declaring
+	// one at all is what needs this — not any particular kind.
+	if (
+		declares &&
+		(database || services.storage || services.cache || services.mail)
+	) {
+		dependencies['@geekmidas/manifest'] =
+			GEEKMIDAS_VERSIONS['@geekmidas/manifest'];
+	}
+
+	// A construct hands back a client from the package that owns it, and each of
+	// those is an optional peer — an app that declares no bucket resolves no S3
+	// SDK. Installed here because the app declared one.
+	if (declares && services.storage) {
+		dependencies['@geekmidas/storage'] =
+			GEEKMIDAS_VERSIONS['@geekmidas/storage'];
+	}
+
+	if (declares && services.cache) {
+		dependencies['@geekmidas/cache'] = GEEKMIDAS_VERSIONS['@geekmidas/cache'];
+	}
+
+	if (declares && services.mail) {
+		dependencies['@geekmidas/emailkit'] =
+			GEEKMIDAS_VERSIONS['@geekmidas/emailkit'];
 	}
 
 	if (database) {

--- a/packages/cli/src/init/generators/test.ts
+++ b/packages/cli/src/init/generators/test.ts
@@ -1,3 +1,4 @@
+import { databaseFor } from '../constructs.js';
 import type {
 	GeneratedFile,
 	TemplateConfig,
@@ -17,6 +18,23 @@ export function generateTestFiles(
 		return [];
 	}
 
+	// The keys the declared database publishes. Migrations connect as the owner
+	// role — the one that may create, alter, and drop; a handler is never given
+	// it, which is the security property the role split exists for.
+	const db = databaseFor(options.name);
+
+	// Single-app projects have no `~/*` alias, so what a test file imports
+	// depends on where it will sit.
+	const declares = !options.monorepo;
+	const schema = declares
+		? '../src/constructs/database.ts'
+		: '~/services/database.ts';
+
+	// Which key holds the URL: the one the construct publishes, or the one the
+	// workspace's per-app secret sets.
+	const runtimeUrl = declares ? db.urlKey : 'DATABASE_URL';
+	const ownerUrl = declares ? db.ownerUrlKey : 'DATABASE_URL';
+
 	return [
 		// kysely.config.ts - Kysely CLI configuration for migrations
 		{
@@ -26,15 +44,14 @@ import { PostgresDialect } from 'kysely';
 import { defineConfig } from 'kysely-ctl';
 import pg from 'pg';
 
+// The owner role's URL — the one that may create, alter, and drop. Both keys
+// are published by the declared database construct; run this under
+// \`gkm exec -- pnpm kysely migrate:latest\` so they are injected.
+const url = Credentials.${ownerUrl} ?? Credentials.${runtimeUrl};
+
 export default defineConfig({
   dialect: new PostgresDialect({
-    pool: new pg.Pool({
-      password: Credentials.POSTGRES_PASSWORD,
-      user: Credentials.POSTGRES_USER,
-      database: Credentials.POSTGRES_DB,
-      port: Number(Credentials.POSTGRES_PORT),
-      host: Credentials.POSTGRES_HOST,
-    }),
+    pool: new pg.Pool({ connectionString: url }),
   }),
   migrations: {
     migrationFolder: './src/db/migrations',
@@ -50,11 +67,11 @@ export default defineConfig({
 import { Kysely, PostgresDialect } from 'kysely';
 import pg from 'pg';
 import { wrapVitestKyselyTransaction } from '@geekmidas/testkit/kysely';
-import type { Database } from '~/services/database.ts';
+import type { Database } from '${schema}';
 
 const connection = new Kysely<Database>({
   dialect: new PostgresDialect({
-    pool: new pg.Pool({ connectionString: process.env.DATABASE_URL }),
+    pool: new pg.Pool({ connectionString: process.env.${runtimeUrl} }),
   }),
 });
 
@@ -64,21 +81,23 @@ export const it = wrapVitestKyselyTransaction<Database>(itVitest, {
 `,
 		},
 
-		// test/globalSetup.ts - Creates test database, provisions users, runs migrations
+		// test/globalSetup.ts - Creates the test database and runs migrations
 		{
 			path: 'test/globalSetup.ts',
 			content: `import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Credentials } from '@geekmidas/envkit/credentials';
 import { PostgresKyselyMigrator } from '@geekmidas/testkit/kysely';
-import { runInitScript } from '@geekmidas/testkit/postgres';
 import { Kysely, PostgresDialect } from 'kysely';
 import { FileMigrationProvider } from 'kysely/migration';
 import pg from 'pg';
 
 export default async function globalSetup() {
-  const databaseUrl = Credentials.DATABASE_URL!;
-  const migrationFolder = path.resolve(import.meta.dirname, '../db/migrations');
+  // \`gkm test\` reconciles the test stage before this runs: the container is
+  // up, the database exists, and its roles are created. What is left is the
+  // schema, which is what migrations are for.
+  const databaseUrl = Credentials.${ownerUrl} ?? Credentials.${runtimeUrl}!;
+  const migrationFolder = path.resolve(import.meta.dirname, '../src/db/migrations');
 
   const db = new Kysely({
     dialect: new PostgresDialect({
@@ -89,22 +108,6 @@ export default async function globalSetup() {
   const migrator = new PostgresKyselyMigrator({
     uri: databaseUrl,
     db,
-    afterCreate: async (uri) => {
-      const initScriptPath = path.resolve(process.cwd(), 'docker/postgres/init.sh');
-      const dbUrl = new URL(Credentials.DATABASE_URL!);
-      const apiUrl = new URL(Credentials.API_DATABASE_URL!);
-      const authUrl = new URL(Credentials.AUTH_DATABASE_URL!);
-
-      const env = {
-        POSTGRES_USER: dbUrl.username,
-        POSTGRES_DB: dbUrl.pathname.slice(1),
-        API_DB_PASSWORD: decodeURIComponent(apiUrl.password),
-        AUTH_DB_PASSWORD: decodeURIComponent(authUrl.password),
-        PGBOSS_DB_PASSWORD: Credentials.PGBOSS_DB_PASSWORD ?? 'pgboss-dev-password',
-      };
-
-      await runInitScript(initScriptPath, uri, env);
-    },
     provider: new FileMigrationProvider({
       fs,
       path,
@@ -123,7 +126,7 @@ export default async function globalSetup() {
 			path: 'test/factory/index.ts',
 			content: `import type { Kysely } from 'kysely';
 import { KyselyFactory } from '@geekmidas/testkit/kysely';
-import type { Database } from '~/services/database.ts';
+import type { Database } from '${schema}';
 import { usersBuilder } from './users.ts';
 
 const builders = { users: usersBuilder };
@@ -145,7 +148,7 @@ export type Factory = ReturnType<typeof createFactory>;
 		{
 			path: 'test/factory/users.ts',
 			content: `import { KyselyFactory } from '@geekmidas/testkit/kysely';
-import type { Database } from '~/services/database.ts';
+import type { Database } from '${schema}';
 
 export const usersBuilder = KyselyFactory.createBuilder<Database, 'users'>(
   'users',

--- a/packages/cli/src/init/index.ts
+++ b/packages/cli/src/init/index.ts
@@ -486,12 +486,20 @@ function printNextSteps(
 	console.log('Next steps:\n');
 	console.log(`  ${cdCommand}`);
 
-	if (options.services.db) {
+	// A project that declares its infrastructure starts nothing by hand:
+	// `gkm dev` reconciles the containers its constructs imply first.
+	if (options.services.db && options.monorepo) {
 		console.log(`  # Start PostgreSQL (if not running)`);
 		console.log(`  docker compose up -d postgres`);
 	}
 
 	console.log(`  ${devCommand}`);
+
+	if (!options.monorepo && options.services.db) {
+		console.log('');
+		console.log('  # Then, once the container is up:');
+		console.log(`  gkm exec -- pnpm kysely migrate:latest`);
+	}
 	console.log('');
 
 	if (options.monorepo) {

--- a/packages/cli/src/init/templates/api.ts
+++ b/packages/cli/src/init/templates/api.ts
@@ -1,3 +1,10 @@
+import {
+	cacheFor,
+	databaseFiles,
+	databaseFor,
+	emailFor,
+	storageFor,
+} from '../constructs.js';
 import { GEEKMIDAS_VERSIONS } from '../versions.js';
 import type {
 	GeneratedFile,
@@ -49,7 +56,29 @@ export const apiTemplate: TemplateConfig = {
 	},
 
 	files: (options: TemplateOptions): GeneratedFile[] => {
-		const { loggerType, routesStructure, monorepo, name } = options;
+		const { loggerType, routesStructure, monorepo, name, services } = options;
+
+		// The ids and env keys the scaffolded constructs own. Derived, so the
+		// files below and the runtime that discovers them cannot disagree.
+		const bucket = storageFor(name);
+		const kv = cacheFor(name);
+		const db = databaseFor(name);
+		const mail = emailFor(name);
+
+		// Single-app projects have no `~/*` alias, so what a generated file
+		// imports depends on where it will sit.
+		const src = (path: string) => (monorepo ? `~/${path}` : `./${path}`);
+
+		// Whether this app declares its infrastructure.
+		//
+		// Single-app projects do: the config gets a `constructs` glob, reconcile
+		// derives their containers, and the handler reaches them by edge. The
+		// fullstack workspace does not yet — its auth app's database role is
+		// created by `docker/postgres/init.sh` and its URL comes from a
+		// per-app secret, neither of which reconcile knows about, so declaring
+		// only the API's half would leave auth pointing at a container that is
+		// no longer the one running.
+		const declares = !monorepo;
 
 		const loggerContent = `import { createLogger } from '@geekmidas/logger/${loggerType}';
 
@@ -107,9 +136,9 @@ export const config = envParser
 				path: getRoutePath('health.ts'),
 				content: monorepo
 					? `import { z } from 'zod';
-import { publicRouter } from '~/router.ts';
+import { router } from '~/router.ts';
 
-export const healthEndpoint = publicRouter
+export const healthEndpoint = router
   .get('/health')
   .output(z.object({
     status: z.string(),
@@ -120,10 +149,10 @@ export const healthEndpoint = publicRouter
     timestamp: new Date().toISOString(),
   }));
 `
-					: `import { e } from '@geekmidas/constructs/endpoints';
-import { z } from 'zod';
+					: `import { z } from 'zod';
+import { router } from './router.ts';
 
-export const healthEndpoint = e
+export const healthEndpoint = router
   .get('/health')
   .output(z.object({
     status: z.string(),
@@ -140,48 +169,64 @@ export const healthEndpoint = e
 			{
 				path: getRoutePath('users/list.ts'),
 				content: modelsImport
-					? `import { e } from '@geekmidas/constructs/endpoints';
-import { ListUsersResponseSchema } from '${modelsImport}/user';
+					? `import { ListUsersResponseSchema } from '${modelsImport}/user';
+import { router } from '${src('router.ts')}';
 
-export const listUsersEndpoint = e
+export const listUsersEndpoint = router
   .get('/users')
   .output(ListUsersResponseSchema)
-  .handle(async () => ({
+${
+	options.database
+		? `  // \`db\` is here because the router named the database construct.
+  .handle(async ({ db }) => ({
+    users: await db.selectFrom('users').select(['id', 'name']).execute(),
+  }));
+`
+		: `  .handle(async () => ({
     users: [
       { id: '550e8400-e29b-41d4-a716-446655440001', name: 'Alice' },
       { id: '550e8400-e29b-41d4-a716-446655440002', name: 'Bob' },
     ],
   }));
 `
-					: `import { e } from '@geekmidas/constructs/endpoints';
-import { z } from 'zod';
+}`
+					: `import { z } from 'zod';
+import { router } from '${src('router.ts')}';
 
 const UserSchema = z.object({
   id: z.string(),
   name: z.string(),
 });
 
-export const listUsersEndpoint = e
+export const listUsersEndpoint = router
   .get('/users')
   .output(z.object({
     users: z.array(UserSchema),
   }))
-  .handle(async () => ({
+${
+	options.database
+		? `  // \`db\` is here because the router named the database construct.
+  .handle(async ({ db }) => ({
+    users: await db.selectFrom('users').select(['id', 'name']).execute(),
+  }));
+`
+		: `  .handle(async () => ({
     users: [
       { id: '1', name: 'Alice' },
       { id: '2', name: 'Bob' },
     ],
   }));
-`,
+`
+}`,
 			},
 			{
 				path: getRoutePath('users/get.ts'),
 				content: modelsImport
-					? `import { e } from '@geekmidas/constructs/endpoints';
-import { IdParamsSchema } from '${modelsImport}/common';
+					? `import { IdParamsSchema } from '${modelsImport}/common';
 import { UserResponseSchema } from '${modelsImport}/user';
+import { router } from '${src('router.ts')}';
 
-export const getUserEndpoint = e
+export const getUserEndpoint = router
   .get('/users/:id')
   .params(IdParamsSchema)
   .output(UserResponseSchema)
@@ -191,10 +236,10 @@ export const getUserEndpoint = e
     email: 'alice@example.com',
   }));
 `
-					: `import { e } from '@geekmidas/constructs/endpoints';
-import { z } from 'zod';
+					: `import { z } from 'zod';
+import { router } from '${src('router.ts')}';
 
-export const getUserEndpoint = e
+export const getUserEndpoint = router
   .get('/users/:id')
   .params(z.object({ id: z.string() }))
   .output(z.object({
@@ -260,17 +305,32 @@ export const authService = {
 			files.push({
 				path: 'src/router.ts',
 				content: `import { e } from '@geekmidas/constructs/endpoints';
-import { UnauthorizedError } from '@geekmidas/errors';
+import { UnauthorizedError } from '@geekmidas/errors';${
+					options.database
+						? `
+import { database } from './constructs/database.ts';`
+						: ''
+				}
 import { authService, type Session } from './services/auth.ts';
 import { logger } from './config/logger.ts';
 
-// Public router - no auth required
-export const publicRouter = e.logger(logger);
+/**
+ * The shared endpoint factory — no session required.
+ *${
+		options.database
+			? `
+ * Naming the database construct is what puts \`db\` in every handler built from
+ * this router. Depend on other constructs per endpoint with \`.dependsOn([…])\`.`
+			: `
+ * Depend on constructs per endpoint with \`.dependsOn([…])\`.`
+ }
+ */
+export const router = e.logger(logger)${options.database ? '.database(database)' : ''};
 
-// Router with auth service available (but session not enforced)
-export const r = publicRouter.services([authService]);
+// The auth client available, but the session not enforced.
+export const r = router.services([authService]);
 
-// Session router - requires active session, throws if not authenticated
+// Requires an active session — throws when there is none.
 export const sessionRouter = r.session<Session>(async ({ services, header }) => {
   const cookie = header('cookie') || '';
   const session = await services.auth.getSession(cookie);
@@ -302,8 +362,100 @@ export const profileEndpoint = sessionRouter
 			});
 		}
 
-		// Add database service if enabled
-		if (options.database) {
+		// The non-monorepo router. The monorepo one is written above, with the
+		// session extractor its auth app needs.
+		if (!monorepo) {
+			files.push({
+				path: 'src/router.ts',
+				content: `import { e } from '@geekmidas/constructs/endpoints';
+import { logger } from './config/logger.ts';${
+					options.database
+						? `
+import { database } from './constructs/database.ts';`
+						: ''
+				}
+
+/**
+ * The shared endpoint factory.
+ *${
+		options.database
+			? `
+ * Naming the database construct is what puts \`db\` in every handler built from
+ * this router. Depend on other constructs per endpoint with \`.dependsOn([…])\`.`
+			: `
+ * Depend on constructs per endpoint with \`.dependsOn([…])\`.`
+ }
+ */
+export const router = e.logger(logger)${options.database ? '.database(database)' : ''};
+`,
+			});
+		}
+
+		// The database — a construct, not a hand-written service.
+		if (options.database && declares) {
+			files.push(...databaseFiles(name));
+		}
+
+		// Object storage — MinIO locally, S3 deployed, one declaration for both.
+		if (services.storage && declares) {
+			files.push({
+				path: 'src/constructs/storage.ts',
+				content: `import { ObjectStorage } from '@geekmidas/constructs/object-storage';
+
+/**
+ * A bucket, declared once.
+ *
+ * Reach it from an endpoint with \`.dependsOn([uploads])\`, which is what makes
+ * \`services.${bucket.service}\` exist and type — and what tells the deploy
+ * target to grant that handler S3 access, and nothing else.
+ */
+export const uploads = new ObjectStorage('${bucket.id}');
+`,
+			});
+		}
+
+		// Mail. Mailpit locally, SES/Resend/SMTP deployed — one client either
+		// way, because every backend speaks SMTP.
+		if (services.mail && declares) {
+			files.push({
+				path: 'src/constructs/email.ts',
+				content: `import { Email } from '@geekmidas/constructs/email';
+
+/**
+ * Outbound mail, declared once.
+ *
+ * Add React templates to \`templates\` and \`sendTemplate\` becomes typed
+ * against them. Reach it with \`.dependsOn([email])\` for
+ * \`services.${mail.service}\`; who delivers it is \`services.mail\` in
+ * \`gkm.config.ts\`.
+ */
+export const email = new Email('${mail.id}', { templates: {} });
+`,
+			});
+		}
+
+		// A cache. Where it lives when deployed is `services.cache` in the
+		// config; the application code is the same either way.
+		if (services.cache && declares) {
+			files.push({
+				path: 'src/constructs/cache.ts',
+				content: `import { Cache } from '@geekmidas/constructs/cache';
+
+/**
+ * A cache, declared once.
+ *
+ * Reach it with \`.dependsOn([cache])\` for \`services.${kv.service}\`. Which
+ * backend serves it — Upstash, ElastiCache, or the database — is
+ * \`services.cache\` in \`gkm.config.ts\`, because the same code caches into
+ * any of them.
+ */
+export const cache = new Cache('${kv.id}');
+`,
+			});
+		}
+
+		// The workspace path, until its auth app declares its own half.
+		if (options.database && !declares) {
 			files.push({
 				path: 'src/services/database.ts',
 				content: `import type { Service, ServiceRegisterOptions } from '@geekmidas/services';
@@ -368,13 +520,12 @@ export const telescope = new Telescope({
 				content: `import { Direction, InMemoryMonitoringStorage, Studio } from '@geekmidas/studio';
 import { Kysely, PostgresDialect } from 'kysely';
 import pg from 'pg';
-import type { Database } from '~/services/database.ts';
-import { envParser } from '~/config/env.ts';
+import type { Database } from '${src(declares ? 'constructs/database.ts' : 'services/database.ts')}';
+import { envParser } from '${src('config/env.ts')}';
 
-// Parse database config for Studio
 const studioConfig = envParser
   .create((get) => ({
-    databaseUrl: get('DATABASE_URL').string(),
+    databaseUrl: get('${declares ? db.urlKey : 'DATABASE_URL'}').string(),
   }))
   .parse();
 

--- a/packages/cli/src/init/templates/index.ts
+++ b/packages/cli/src/init/templates/index.ts
@@ -269,26 +269,33 @@ export const deployTargetChoices = [
 /**
  * Services choices for multi-select prompt
  */
+/**
+ * What the project declares — and therefore which containers it runs.
+ *
+ * Each choice scaffolds a construct rather than a container: the container is
+ * what `gkm dev` derives from the declaration, which is why the descriptions
+ * name the construct and the titles name the thing you will see running.
+ */
 export const servicesChoices = [
 	{
 		title: 'PostgreSQL',
 		value: 'db',
-		description: 'PostgreSQL database',
+		description: 'A declared database — KyselyDatabase construct',
 	},
 	{
 		title: 'Redis',
 		value: 'cache',
-		description: 'Redis cache',
+		description: 'A declared cache — Cache construct',
 	},
 	{
 		title: 'Mailpit',
 		value: 'mail',
-		description: 'Email testing service (dev only)',
+		description: 'Declared outbound mail — Email construct',
 	},
 	{
 		title: 'MinIO',
 		value: 'storage',
-		description: 'S3-compatible object storage (dev only)',
+		description: 'A declared bucket — ObjectStorage construct',
 	},
 ];
 

--- a/packages/cli/src/init/templates/minimal.ts
+++ b/packages/cli/src/init/templates/minimal.ts
@@ -1,3 +1,4 @@
+import { databaseFiles, databaseFor } from '../constructs.js';
 import { GEEKMIDAS_VERSIONS } from '../versions.js';
 import type {
 	GeneratedFile,
@@ -45,7 +46,10 @@ export const minimalTemplate: TemplateConfig = {
 	},
 
 	files: (options: TemplateOptions): GeneratedFile[] => {
-		const { loggerType, routesStructure } = options;
+		const { loggerType, routesStructure, name } = options;
+
+		// The id and env keys the scaffolded database owns.
+		const db = databaseFor(name);
 
 		const loggerContent = `import { createLogger } from '@geekmidas/logger/${loggerType}';
 
@@ -110,43 +114,9 @@ export const healthEndpoint = e
 			},
 		];
 
-		// Add database service if enabled
+		// The database — a construct, not a hand-written service.
 		if (options.database) {
-			files.push({
-				path: 'src/services/database.ts',
-				content: `import type { Service, ServiceRegisterOptions } from '@geekmidas/services';
-import { Kysely, PostgresDialect } from 'kysely';
-import pg from 'pg';
-
-// Define your database schema
-export interface Database {
-  // Add your tables here
-}
-
-export const databaseService = {
-  serviceName: 'database' as const,
-  async register({ envParser, context }: ServiceRegisterOptions) {
-    const logger = context.getLogger();
-    logger.info('Connecting to database');
-
-    const config = envParser
-      .create((get) => ({
-        url: get('DATABASE_URL').string(),
-      }))
-      .parse();
-
-    const db = new Kysely<Database>({
-      dialect: new PostgresDialect({
-        pool: new pg.Pool({ connectionString: config.url }),
-      }),
-    });
-
-    logger.info('Database connection established');
-    return db;
-  },
-} satisfies Service<'database', Kysely<Database>>;
-`,
-			});
+			files.push(...databaseFiles(name));
 		}
 
 		// Add Telescope config if enabled
@@ -171,13 +141,13 @@ export const telescope = new Telescope({
 				content: `import { Direction, InMemoryMonitoringStorage, Studio } from '@geekmidas/studio';
 import { Kysely, PostgresDialect } from 'kysely';
 import pg from 'pg';
-import type { Database } from '~/services/database.ts';
-import { envParser } from '~/config/env.ts';
+import type { Database } from './constructs/database.ts';
+import { envParser } from './config/env.ts';
 
-// Parse database config for Studio
+// The key the database construct publishes — not a hand-written DATABASE_URL.
 const studioConfig = envParser
   .create((get) => ({
-    databaseUrl: get('DATABASE_URL').string(),
+    databaseUrl: get('${db.urlKey}').string(),
   }))
   .parse();
 

--- a/packages/cli/src/init/templates/serverless.ts
+++ b/packages/cli/src/init/templates/serverless.ts
@@ -1,3 +1,4 @@
+import { databaseFiles } from '../constructs.js';
 import { GEEKMIDAS_VERSIONS } from '../versions.js';
 import type {
 	GeneratedFile,
@@ -45,7 +46,7 @@ export const serverlessTemplate: TemplateConfig = {
 	},
 
 	files: (options: TemplateOptions): GeneratedFile[] => {
-		const { loggerType, routesStructure } = options;
+		const { loggerType, routesStructure, name } = options;
 
 		const loggerContent = `import { createLogger } from '@geekmidas/logger/${loggerType}';
 
@@ -126,6 +127,12 @@ export const helloFunction = f
 `,
 			},
 		];
+
+		// The database, when this project has one. A `pgboss` events backend
+		// implies one, which is why a worker gets here without asking for it.
+		if (options.database) {
+			files.push(...databaseFiles(name));
+		}
 
 		// Add Telescope config if enabled
 		if (options.telescope) {

--- a/packages/cli/src/init/templates/worker.ts
+++ b/packages/cli/src/init/templates/worker.ts
@@ -1,3 +1,4 @@
+import { databaseFiles } from '../constructs.js';
 import { GEEKMIDAS_VERSIONS } from '../versions.js';
 import type {
 	GeneratedFile,
@@ -44,7 +45,7 @@ export const workerTemplate: TemplateConfig = {
 	},
 
 	files: (options: TemplateOptions): GeneratedFile[] => {
-		const { loggerType, routesStructure } = options;
+		const { loggerType, routesStructure, name } = options;
 
 		const loggerContent = `import { createLogger } from '@geekmidas/logger/${loggerType}';
 
@@ -195,6 +196,12 @@ export const cleanupCron = cron('0 0 * * *')
 `,
 			},
 		];
+
+		// The database, when this project has one. A `pgboss` events backend
+		// implies one, which is why a worker gets here without asking for it.
+		if (options.database) {
+			files.push(...databaseFiles(name));
+		}
 
 		// Add Telescope config if enabled
 		if (options.telescope) {

--- a/packages/cli/src/init/versions.ts
+++ b/packages/cli/src/init/versions.ts
@@ -39,6 +39,7 @@ export const GEEKMIDAS_VERSIONS = {
 	'@geekmidas/errors': '~9.0.2',
 	'@geekmidas/events': '~9.0.2',
 	'@geekmidas/logger': '~9.0.2',
+	'@geekmidas/manifest': '~9.0.2',
 	'@geekmidas/rate-limit': '~9.0.2',
 	'@geekmidas/schema': '~9.0.2',
 	'@geekmidas/services': '~9.0.2',

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,5 @@
+import type { ServicesConfig } from './workspace/types.js';
+
 export type MainProvider = 'aws' | 'server';
 export type LegacyProvider =
 	| 'server'
@@ -282,6 +284,17 @@ export interface ProvidersConfig {
 }
 
 export interface GkmConfig {
+	/**
+	 * Where the things no construct implies live.
+	 *
+	 * The same block a workspace config carries, and the same split: `db` and
+	 * `storage` are derived from the declared `KyselyDatabase` and
+	 * `ObjectStorage` and are ignored here, while `cache`, `mail`, and `events`
+	 * name a *backend* — where the cache lives, who delivers the mail, which
+	 * broker carries events. A single-app project had no way to say any of that
+	 * before, so its event backend could only be guessed.
+	 */
+	services?: ServicesConfig;
 	/**
 	 * Constructs glob pattern — one glob, every kind.
 	 *

--- a/packages/cli/src/workspace/index.ts
+++ b/packages/cli/src/workspace/index.ts
@@ -232,6 +232,11 @@ export function wrapSingleAppAsWorkspace(
 		}
 	}
 
+	// `services:` on the config itself wins over anything inferred from the
+	// compose block: it is the statement, and the compose block is a deploy-side
+	// list that only happens to name some of the same things.
+	Object.assign(normalizedServices, config.services ?? {});
+
 	const apiApp: NormalizedAppConfig = {
 		type: 'backend',
 		path: '.',


### PR DESCRIPTION
Two halves of the same gap: the paradigm shipped, but neither the CLI's output nor the documentation had followed it.

## The CLI

Reconcile only runs when an app configures a `constructs` glob — `usesConstructs()` is a hard switch. `gkm init` never emitted one, so **every project the CLI produced fell back to the pre-constructs path**, and the v10 engine was unreachable from the CLI's own output. The templates taught the shape the paradigm removes: a hand-written database `Service` reading `DATABASE_URL`, beside a `docker-compose.yml` pinning the Postgres it happened to point at.

- All four templates declare. `src/constructs/database.ts` holds a `KyselyDatabase`; the api template adds `ObjectStorage`, `Cache`, and `Email` per the init selections. The router names the database, so `db` reaches handlers by declaration.
- `init/constructs.ts` derives every id and env key through `@geekmidas/manifest` itself — three generators need the same three facts, and deriving them separately is how a scaffold comes to disagree with the runtime that discovers it.
- **`GkmConfig.services` is new, and it is what makes the switch safe.** A single-app project could only imply its backends from `docker.compose.services`, which maps postgres and redis and nothing else — a worker scaffold would have lost its broker the moment reconcile took over. `db` and `storage` stay absent by design: derived, and ignored rather than obeyed.

Three bugs surfaced on the way, all reachable from the same scaffold: the test setup dereferenced `Credentials.API_DATABASE_URL!` in single-app projects where that key never exists; nothing created the `users` table the generated endpoints and factories assume; and `@geekmidas/manifest` was missing from the version sync, so nothing could scaffold a dependency on the package the model runs on.

## The docs

Getting-started opened on encrypted secrets and taught a hand-written service beside `services: { db: true }` — the three-places-one-string shape the paradigm exists to remove. Every page agreed with that version, so a reader arriving at `next` learned v9 with an RFC bolted on.

Rewritten around the declaration: getting-started, project-structure (was documenting a `packages/api` that no longer exists), constructs (the Constructs section it never had; `.services()` documented as the escape hatch), cli (reconcile, the real config reference, the derived-vs-selection split), dev-server, workspaces, testing, deployment, index, README. **New page for `@geekmidas/manifest`** — the seam every target reads had no documentation and no sidebar entry.

## Deliberately not done

**The fullstack template stays on the pre-constructs path.** I migrated it, then reverted: its auth app's database role comes from `docker/postgres/init.sh` and its URL from a per-app secret, and reconcile knows about neither. Adding the glob to the API app alone flips the whole workspace onto reconcile and leaves auth pointing at a container that is no longer the one running. It needs the auth app to declare its own half — most likely a `database.schema()` tenant. Marked in `fullstack-init.md`, on the docs landing page, and in the README roadmap.

The root `docker-compose.yml` is still generated for single-app projects even though reconcile writes `.gkm/docker-compose.yml` and never reads it. Removing it is a one-line gate plus four test rewrites.

## Verification

- `tsc --noEmit` clean — the 4 remaining errors in `deploy/domain.ts` and `dev/index.ts` are identical with these changes stashed.
- CLI tests: 123/123 init, 241/241 init+workspace. The full suite's 17 AWS-mock failures are unchanged before and after.
- `pnpm lint`: 48 warnings before, 48 after.
- `gkm init` run for all four templates — **69 generated TypeScript files, all parsing**; the api project shows the glob, four declarations, and `db` reaching the handler through the router.
- `vitepress build` clean, dead-link check included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQNqqCJszgW2Paof5KJd8R