### PR TITLE
The outstanding list is current, and reachable

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Constructs Paradigm (RFC)', link: '/guide/constructs-paradigm' },
+          { text: 'What Is Outstanding', link: '/guide/constructs-outstanding' },
           { text: 'Deploy Walkthrough (RFC)', link: '/guide/deploy-walkthrough' },
           { text: 'Fullstack Init', link: '/guide/fullstack-init' },
           { text: 'Development Server', link: '/guide/dev-server' },

--- a/apps/docs/guide/constructs-outstanding.md
+++ b/apps/docs/guide/constructs-outstanding.md
@@ -1,0 +1,6 @@
+<!--
+  Rendered from the canonical design doc at docs/design/constructs-outstanding.md.
+  Edit that file, not this one — this page is a VitePress include of it.
+-->
+
+<!--@include: ../../../docs/design/constructs-outstanding.md-->

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -247,7 +247,7 @@ in step:
 export const database = new KyselyDatabase<Database, 'Example'>('Example');
 
 export const replica = database.reader();       // ExampleReader — read-only role
-export const cache = database.cache();          // ExampleCache — a cache in this DB
+export const cache = database.cache();          // ExampleCache — cached *in* this database
 export const acme = database.schema<TenantDB, 'Acme'>('Acme');  // its own role and URL
 database.owner;                                 // the DDL role, for migrations
 ```
@@ -255,6 +255,26 @@ database.owner;                                 // the DDL role, for migrations
 `reader()` is enforced by the reader role's grants, not by which endpoint it
 reaches — which is why it stays correct even where a stage runs a single
 instance and the reader resolves to the writer's address.
+
+`cache()` gives you a **cache whose storage is this database**: entries are rows
+in a table inside it (`cache` by default, or pass one), in this database's
+schema, reached by this database's role. It is the stronger statement of the
+two — `new Cache('Sessions')` says the app caches and leaves *where* to the
+deployment, while `database.cache()` says it caches **here**, which is a fact
+about the application and so belongs in its code. Declaring it this way pins it:
+`services.cache: 'upstash'` moves a standalone cache and does not move this one.
+
+The client is a `CacheClient` either way — a key/value store, not a query
+builder. Typing it as the parent would be a convenience that lies.
+
+```typescript
+.dependsOn([cache])
+.handle(async ({ services }) => services.exampleCache.get(key))
+```
+
+The table is DDL, so reconcile's owner role creates it. The driver never creates
+it lazily, for the same reason a handler cannot migrate: the role a handler runs
+as may not create anything.
 
 ### Credentials have a shape
 

--- a/apps/docs/packages/cache.md
+++ b/apps/docs/packages/cache.md
@@ -11,10 +11,18 @@ import { Cache } from '@geekmidas/constructs/cache';
 export const sessions = new Cache('Sessions');
 ```
 
-Where it lives — Upstash, ElastiCache, or a table in the database — is
+Where it lives — Upstash, ElastiCache, or a table in a database — is
 `services.cache` in `gkm.config.ts`, because the same application code caches
 into any of them. The scheme in the injected URL picks the driver, so an app
 caching in Postgres never resolves a Redis client.
+
+To say it caches in a *particular* database rather than leaving the choice to
+the deployment, declare it from that database — entries become a table inside
+it, and the config no longer moves it:
+
+```typescript
+export const cache = database.cache();  // storage is `database`, not a stage decision
+```
 :::
 
 ## Installation

--- a/apps/docs/packages/constructs.md
+++ b/apps/docs/packages/constructs.md
@@ -150,10 +150,36 @@ that throws at runtime. You cannot call a queue worker; you send to its queue.
 export const database = new KyselyDatabase<Database, 'Orders'>('Orders');
 
 export const replica = database.reader();                    // OrdersReader
-export const cache = database.cache();                       // OrdersCache
+export const cache = database.cache();                       // cached *in* this database
 export const acme = database.schema<TenantDB, 'Acme'>('Acme'); // its own role + URL
 database.owner;                                              // the DDL role
 ```
+
+#### `database.cache()`
+
+A cache **backed by this database** — entries are rows in a table inside it,
+created in this database's schema and reached by its role:
+
+```typescript
+database.cache();                          // OrdersCache, table `cache`
+database.cache('Sessions');                // a different id
+database.cache('Sessions', { table: 'kv' }); // a different table
+```
+
+It is the stronger of the two forms. `new Cache('Sessions')` says the app caches
+and leaves *where* to the deployment; this says it caches **here**, which is a
+fact about the application rather than about a stage — so the declaration wins
+over the config, and `services.cache: 'upstash'` does not move it.
+
+What that buys beyond being explicit: the table's schema and the role that
+reaches it come from this database rather than from a second convention, and the
+backend never has to guess which database "the database" meant in an app that
+declares two.
+
+The client is still a `CacheClient` — a key/value store, not a query builder, so
+this returns a `Cache` and not a `KyselyDatabase`. And the table is DDL, so
+whatever applies DDL creates it: a handler's role may not create anything, which
+is the same reason the Postgres driver does not create it lazily.
 
 `.database(database)` on a factory puts the client in the handler context as
 `db`, and the execution wrapper is what opens the transaction and applies the

--- a/apps/docs/packages/manifest.md
+++ b/apps/docs/packages/manifest.md
@@ -41,8 +41,10 @@ ConstructManifest` checks the shape while keeping the literal types, so
 
 ## Declaration kinds
 
-Thirteen, as a discriminated union — exhaustiveness *and* per-kind fields, with
-no shape carrying a field that belongs to a different kind:
+Fifteen, as a discriminated union — exhaustiveness *and* per-kind fields, with
+no shape carrying a field that belongs to a different kind. Thirteen of them are
+things a target *provisions*; `function` and `cron` carry a handler and reach a
+target through the function pipeline instead:
 
 | Kind | Declared by | Notes |
 |------|-------------|-------|

--- a/apps/docs/packages/manifest.md
+++ b/apps/docs/packages/manifest.md
@@ -53,7 +53,7 @@ target through the function pipeline instead:
 | `database-schema` | `database.schema()` | its own role and URL |
 | `objects` | `ObjectStorage` | `versioned` |
 | `file-server` | `FileServer` | derives from `objects` — it shares the parent's *contents*, not its credentials |
-| `cache` | `Cache` | `of` when it lives in a database |
+| `cache` | `Cache` | `of` + `table` when declared from a database — entries are a table in it |
 | `email` | `Email` | |
 | `secret` | — | platform-generated, one opaque string |
 | `credential` | `Credential` | third-party, several fields, validated |

--- a/docs/design/constructs-outstanding.md
+++ b/docs/design/constructs-outstanding.md
@@ -9,16 +9,26 @@ gets worked top-down, which is how a decision nobody made gets made by whoever
 picks up the ticket. Everything under "blocked on a decision" needs an answer
 before code, and the answer is not obvious from the codebase.
 
-**Status at the time of writing:** the construct half of the model is largely
-complete — thirteen declaration kinds, and a construct for each one that needs
-it. The local target reconciles all thirteen; the AWS target provisions twelve.
+**Status, re-verified against the code (2026-09-02):** the construct half of the
+model is complete. The declaration union has **fifteen** members, thirteen of
+which a target provisions — `function` and `cron` carry a handler and reach a
+target through the function pipeline instead. Every one of the thirteen has a
+construct, and the local target reconciles all of them.
+
+The AWS target now has a provisioner for all thirteen too, which is a change
+from the last writing and a smaller one than it sounds: `rest-api` provisions
+the surface and nothing on it. See §1.4.
+
+Where a claim below was checked rather than remembered, it says so.
 
 ---
 
-## 1. The AWS target — twelve of thirteen kinds
+## 1. The AWS target — thirteen provisioners, one of them empty
 
-`rest-api` is the only kind left, and it is blocked on §2 rather than on a
-decision.
+`PROVISIONERS` in `packages/cloud/src/sst/fromManifest.ts` covers every
+provisionable kind. What is left is not a missing entry but a hollow one:
+`rest-api` provisions an API with no routes on it, and that is blocked on §2
+rather than on a decision.
 
 Nothing in this section has been deployed. The components are verified by their
 decisions being pure functions — `provisionerFor`, `assertProvides`,
@@ -132,12 +142,23 @@ long after the stack reported success. The same page also gave a guard worth
 having: not every region has an SMTP endpoint, and deriving for one that does not
 produces a credential that can never work.
 
-### 1.4 `rest-api` — *blocked on §2*
+### 1.4 `rest-api` — *provisioned, empty; blocked on §2*
 
-`packages/cloud/src/sst/aws/Api.ts` already exists and is not wired in, because
-the surface node declares `endpoints: []` for an application's own API. Routes
-still reach the deploy target through the separate `RouteInfo[]` pipeline. This
-unblocks itself when the endpoint merge lands.
+`RestApiSurface` is wired in and provisions the surface. It is deliberately not
+`Api` — that component takes a route table and validates each route's
+environment at synth, and it needs routes; the manifest's `rest-api` node still
+declares `endpoints: []` for an application's own API.
+
+So an API Gateway comes up that 404s everything, and it is still worth
+provisioning, because what everything downstream needs is the **address**: a
+site inlines it as `VITE_API_URL`, an auth server puts it on its trusted-origin
+list, and the cookie domain derives from it. Those are blocked on the API
+existing, not on it answering.
+
+Routes still reach the target through the separate `RouteInfo[]` pipeline —
+`Api.fromManifest(stack, 'Api', manifest.routes)` — which is the concrete shape
+of §2's "two pipelines describe the same routes". The two components collapse
+into one when the endpoint merge lands.
 
 ---
 
@@ -397,6 +418,62 @@ prototype rather than plan:
 
 Nothing has run against a real Dokploy server.
 
+## 6c. The CLI and what it scaffolds — *partly done*
+
+The model reached the CLI's own output late. Reconcile only runs when an app
+configures a `constructs` glob — `usesConstructs` is a hard switch — and
+`gkm init` did not emit one, so every project the CLI produced took the
+pre-constructs path and the engine was unreachable from the tool that generates
+its users. Single-app templates now declare: a `KyselyDatabase`, plus
+`ObjectStorage`, `Cache`, and `Email` for what init selected, with the glob that
+makes reconcile read them.
+
+### 6c.1 The fullstack workspace — *work*
+
+It stays on the pre-constructs path, and deliberately: the auth app's database
+role is created by `docker/postgres/init.sh` and its URL comes from a per-app
+secret, neither of which reconcile knows about. Declaring only the API's half
+flips the whole workspace onto reconcile — the switch is per *workspace*, not
+per app — and leaves auth pointing at a container that is no longer the one
+running.
+
+It moves when the auth app declares its own half, most likely as a
+`database.schema()` tenant of the API's database: that is exactly the kind whose
+whole purpose is a second app with its own role, its own schema, and its own
+URL. What has to move with it is the per-app secret that carries `DATABASE_URL`
+today, since the tenant publishes its own key.
+
+### 6c.2 A generated `docker-compose.yml` nothing reads — *work*
+
+`gkm init` still writes one at the project root, and on the declared path
+reconcile writes its own at `.gkm/docker-compose.yml` and never reads that one.
+A stale file pinning a Postgres version and a database name beside a declaration
+that decides both is the duplication this design removes, restated in the
+scaffold. Removing it for single-app projects is a gate at the call site plus
+four test rewrites; the fullstack path still needs its copy until §6c.1 lands.
+
+### 6c.3 The glob is a switch with a sharp edge — *documented, no action yet*
+
+Because derived containers are ignored rather than obeyed, adding a `constructs`
+glob to an existing project **removes** its Postgres and MinIO until it declares
+the database and the bucket that imply them. That is the intended semantics —
+a config and a declaration that disagree is the failure the model exists to
+remove — but it is a migration hazard with no warning attached. The cheap
+version is a diagnostic: a glob is configured, `services.db` is set, and no
+`database` kind was discovered, so say which container is about to disappear and
+why.
+
+### 6c.4 `secret` has no construct — *by design*
+
+Twelve of the thirteen provisionable kinds are declared by a construct anyone
+can instantiate. `secret` is not: it is emitted by `BetterAuth` for its signing
+key, and nothing else declares one. This is the lifecycle split §3 argues —
+a secret is generated and rotated by the platform, so there is nothing for an
+author to pass. Recorded because "every kind has a construct" is otherwise the
+obvious thing to assume, and it is off by one.
+
+---
+
 ## 7. Correctness and infrastructure gaps
 
 ### 7.1 `provisionOrder` orders `of`, not `dependencies` — *work*
@@ -435,18 +512,23 @@ being two callers rather than one.
 
 ### 7.4 Test suites that need containers — *environment*
 
-`@geekmidas/events` had **no vitest config**, so its specs were never discovered
-by the root `projects: ['packages/*']`. Adding one runs 114 tests, of which the
-RabbitMQ and pg-boss ones need brokers. The same is true of the Postgres-bound
-integration specs in `constructs` and the LocalStack-bound `deploy` specs in
-`cli`.
+The `@geekmidas/events` half is **resolved** — it has a vitest config, and its
+specs are discovered. What that surfaced remains: the RabbitMQ and pg-boss ones
+need brokers, as do the Postgres-bound integration specs in `constructs` and the
+LocalStack-bound `deploy` specs in `cli`.
+
+Worth knowing, because it is louder than a skipped suite: with nothing running,
+`vitest list` at the repo root fails during **collection** with an
+`ECONNREFUSED` aggregate error rather than reporting the tests it could not
+reach. A collect-time connection is why — the failure is in enumerating the
+suite, not in running it.
 
 None of this is new breakage — it is previously invisible breakage now visible,
 plus a documented port conflict with another project on 5432/4566/8079.
 
 ### 7.5 Dev-server resilience — *parked, documented*
 
-See [dev-server-resilience-design](../../packages/cli/docs/dev-server-resilience-design.md).
+See [dev-server-resilience-design](https://github.com/geekmidas/toolbox/blob/main/packages/cli/docs/dev-server-resilience-design.md).
 The supervisor, the tsx PID registry, and worker-thread hot reload are designed
 and unbuilt; the Zod duplicate-id error on HMR is subsumed by the last of those
 and is worked around today by clearing the registry in `discover` and the
@@ -494,4 +576,7 @@ bill and the security model, and the rest follows them.
    is the largest remaining piece of correctness debt in the model.
 3. **§5 kitchen-sink frontend** — makes four already-built derivations observable
    rather than merely tested, and is cheap.
-4. **§7.2** — small, and the kind of gap that hides others.
+4. **§6c.1 the fullstack workspace** — the last path that still declares its
+   infrastructure twice, and the one a new user is most likely to meet, since it
+   is one of the two templates the init prompt offers.
+5. **§7.2** — small, and the kind of gap that hides others.

--- a/packages/cli/src/init/templates/api.ts
+++ b/packages/cli/src/init/templates/api.ts
@@ -444,10 +444,14 @@ export const email = new Email('${mail.id}', { templates: {} });
 /**
  * A cache, declared once.
  *
- * Reach it with \`.dependsOn([cache])\` for \`services.${kv.service}\`. Which
- * backend serves it — Upstash, ElastiCache, or the database — is
- * \`services.cache\` in \`gkm.config.ts\`, because the same code caches into
- * any of them.
+ * Reach it with \`.dependsOn([cache])\` for \`services.${kv.service}\`. This
+ * form says the app caches and leaves *where* to the deployment: which backend
+ * serves it — Upstash, ElastiCache, or a database — is \`services.cache\` in
+ * \`gkm.config.ts\`, because the same code caches into any of them.
+ *
+ * To say it caches in a particular database instead, declare it from that
+ * database — \`database.cache()\` — and entries become a table in it, in its
+ * schema and reached by its role, which config can no longer move.
  */
 export const cache = new Cache('${kv.id}');
 `,


### PR DESCRIPTION
Targets `main`. #15 is merged.

**Carries a commit that #15 left behind.** #15 was merged at `2f5386fd`, one commit before `b5360477` — the `database.cache()` correction, which is therefore not in `main`. It is cherry-picked here so it isn't lost with the stale branch: `database.cache()` returns a cache **whose storage is that database**, not a cache that happens to sit beside one. That touches `getting-started`, `packages/constructs`, `packages/cache`, and the comment in the scaffolded `src/constructs/cache.ts`.

The rest is the outstanding list.

I went to answer "do we have any outstanding constructs?" from `docs/design/constructs-outstanding.md` and found three claims had drifted. Rather than write a second document that would immediately compete with it, this refreshes the canonical one and publishes it.

## What had gone stale

**The AWS target has a provisioner for all thirteen provisionable kinds, not twelve.** The doc's headline said `rest-api` was "the only kind left". `PROVISIONERS` now covers it — but that reads as done, and it isn't: `RestApiSurface` provisions an API with **no routes on it**, because the surface node still declares `endpoints: []`. "Twelve of thirteen" understated the work; "thirteen of thirteen" would overstate it. §1.4 now says what is actually there, and why an empty surface is still worth provisioning — the address is what a site inlines as `VITE_API_URL` and what an auth server trusts, and that is blocked on the API existing, not on it answering.

**The union is fifteen members, not thirteen.** Thirteen is the count a target provisions; `function` and `cron` carry a handler and reach a target through the separate function pipeline. Conflating the two made the kinds table look two rows wrong.

**§7.4 is half resolved.** `@geekmidas/events` has a vitest config now. What it surfaced doesn't go away, and the failure mode is worth naming: with no containers running, `vitest list` at the repo root fails during *collection* with `ECONNREFUSED` rather than reporting a skipped suite, because the connection happens at collect time.

## What was missing entirely — §6c

The document covered the constructs, the manifest, and the cloud target, and said nothing about the CLI. That is where the model reached users last, and where the remaining duplication now lives:

- **§6c.1 the fullstack workspace** still declares its infrastructure twice. Its auth app's database role comes from `docker/postgres/init.sh` and its URL from a per-app secret; the constructs switch is per *workspace*, so declaring only the API's half breaks auth. It moves when the auth app declares a `database.schema()` tenant.
- **§6c.2** `gkm init` still writes a `docker-compose.yml` that nothing reads on the declared path.
- **§6c.3** adding a `constructs` glob to an existing project **removes** its Postgres and MinIO until it declares them. That is the intended semantics — a config and a declaration that disagree is the failure this model removes — but it is an unwarned migration hazard, and the cheap fix is a diagnostic naming the container about to disappear.
- **§6c.4** `secret` has no construct anyone can instantiate; only `BetterAuth` emits one. By design, per the §3 lifecycle split, but recorded because "every kind has a construct" is otherwise the obvious thing to assume and it is off by one.

## Published

It lived in `docs/design/` and was reachable from nowhere. It is now a VitePress include beside the paradigm RFC, with a sidebar entry. One cross-doc link (`dev-server-resilience-design`) becomes absolute so it resolves both on GitHub and in the rendered page — the convention the paradigm doc already uses.

`vitepress build` clean (dead-link check included), CLI typecheck clean, init tests 123/123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQNqqCJszgW2Paof5KJd8R